### PR TITLE
fix(replication): atomic job slot prevents TOCTOU double execution

### DIFF
--- a/internal/replication/replication_test.go
+++ b/internal/replication/replication_test.go
@@ -4,6 +4,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -337,5 +338,85 @@ func TestStoreCRUD(t *testing.T) {
 	}
 	if _, err := st.Get(ctx, id); err != ErrNotFound {
 		t.Errorf("tras delete debería ser ErrNotFound: %v", err)
+	}
+}
+
+func TestRunnerTryAcquireRelease(t *testing.T) {
+	r := NewRunner(nil, longops.New(hub.NewHub()), hub.NewHub(), nil, t.TempDir(), false)
+	id := int64(42)
+	if !r.TryAcquire(id) {
+		t.Fatal("primera adquisición debería tener éxito")
+	}
+	if r.TryAcquire(id) {
+		t.Fatal("segunda adquisición del mismo id debería fallar")
+	}
+	r.Release(id)
+	if !r.TryAcquire(id) {
+		t.Fatal("tras Release, TryAcquire debería tener éxito otra vez")
+	}
+	r.Release(id)
+	// Id diferente: sin interferencia
+	if !r.TryAcquire(99) {
+		t.Fatal("TryAcquire con id distinto debería tener éxito")
+	}
+	r.Release(99)
+}
+
+func TestRunNowPreventsDoubleExecution(t *testing.T) {
+	fakeBin(t)
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	st := NewStore(d)
+	id, err := st.Create(context.Background(), localJob())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ops := longops.New(hub.NewHub())
+	r := NewRunner(st, ops, hub.NewHub(), nil, t.TempDir(), true)
+	r.testGate = make(chan struct{})
+
+	// Primera llamada: adquiere el slot, lanza execute, se bloquea en el gate.
+	done1 := make(chan error, 1)
+	go func() {
+		done1 <- r.RunNow(context.Background(), id)
+	}()
+	time.Sleep(100 * time.Millisecond) // margen para que la goroutine adquiera el slot
+
+	// Segunda llamada: el slot ya está tomado → ErrAlreadyRunning.
+	err2 := r.RunNow(context.Background(), id)
+	if !errors.Is(err2, ErrAlreadyRunning) {
+		t.Fatalf("segunda RunNow debería devolver ErrAlreadyRunning, got %v", err2)
+	}
+
+	// Liberar el gate: la primera ejecución continúa.
+	close(r.testGate)
+	if err := <-done1; err != nil {
+		t.Fatalf("primera RunNow falló: %v", err)
+	}
+
+	// Esperar a que execute termine (mockRun tarda ~3s: sleep 2 + sleep 1) y
+	// libere el slot. Poll TryAcquire hasta que esté libre con timeout.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout esperando a que el slot se libere tras la ejecución")
+		}
+		if r.TryAcquire(id) {
+			r.Release(id)
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	r.testGate = nil
+
+	// Tras completarse, el slot está libre otra vez.
+	if err := r.RunNow(context.Background(), id); err != nil {
+		t.Fatalf("RunNow tras completarse la primera ejecución: %v", err)
 	}
 }

--- a/internal/replication/runner.go
+++ b/internal/replication/runner.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"easyzfs/internal/executil"
@@ -37,11 +38,15 @@ type Runner struct {
 	hist    HistoryRecorder
 	dataDir string // dir de datos del daemon (para ssh/)
 	mock    bool   // MOCK=1: sin zfs/ssh reales (ops simuladas)
+
+	inFlight   map[int64]struct{}
+	inFlightMu sync.Mutex
+	testGate   chan struct{} // solo tests de concurrencia: execute bloquea aquí si != nil
 }
 
 // NewRunner crea el runner de replicación.
 func NewRunner(st *Store, ops *longops.Manager, h *hub.Hub, hist HistoryRecorder, dataDir string, mock bool) *Runner {
-	return &Runner{store: st, ops: ops, h: h, hist: hist, dataDir: dataDir, mock: mock}
+	return &Runner{store: st, ops: ops, h: h, hist: hist, dataDir: dataDir, mock: mock, inFlight: map[int64]struct{}{}}
 }
 
 // Store expone el store (handlers HTTP).
@@ -58,7 +63,29 @@ func Target(j *Job) string {
 // ErrAlreadyRunning — ya hay una ejecución en curso de ese job (HTTP 409).
 var ErrAlreadyRunning = errors.New("ya hay una replicación en curso para este job")
 
+// TryAcquire reserva el slot del job de forma atómica. Si el slot ya está tomado
+// devuelve false; si está libre lo toma y devuelve true. Release() lo libera.
+// Cierra la ventana TOCTOU entre Running() y ops.Start() (auditoría 7-Ago-2026).
+func (r *Runner) TryAcquire(id int64) bool {
+	r.inFlightMu.Lock()
+	defer r.inFlightMu.Unlock()
+	if _, ok := r.inFlight[id]; ok {
+		return false
+	}
+	r.inFlight[id] = struct{}{}
+	return true
+}
+
+// Release libera el slot del job (se llama en defer desde execute).
+func (r *Runner) Release(id int64) {
+	r.inFlightMu.Lock()
+	delete(r.inFlight, id)
+	r.inFlightMu.Unlock()
+}
+
 // Running — ¿hay una op de replicación en curso para este job?
+// (lectura informativa del registro de longops; la prevención de doble
+// ejecución la hace TryAcquire, que es atómica).
 func (r *Runner) Running(j *Job) bool {
 	t := Target(j)
 	for _, op := range r.ops.List() {
@@ -75,7 +102,7 @@ func (r *Runner) RunNow(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	if r.Running(j) {
+	if !r.TryAcquire(j.ID) {
 		return ErrAlreadyRunning
 	}
 	go r.execute(context.Background(), *j)
@@ -124,7 +151,7 @@ func (r *Runner) check(ctx context.Context) {
 		if next.After(now) {
 			continue
 		}
-		if r.Running(&j) {
+		if !r.TryAcquire(j.ID) {
 			continue
 		}
 		go r.execute(context.Background(), j)
@@ -134,6 +161,10 @@ func (r *Runner) check(ctx context.Context) {
 // execute — una ejecución completa: snapshot → pipeline send|recv (longop) →
 // bookmark + prune (éxito) o retry completo / error claro (fallo incremental).
 func (r *Runner) execute(ctx context.Context, j Job) {
+	defer r.Release(j.ID)
+	if r.testGate != nil {
+		<-r.testGate
+	}
 	ok := false
 	detail := ""
 	bookmark := j.LastBookmark


### PR DESCRIPTION
Closes #13 (hallazgo 2.1)

Runner.RunNow and Runner.check used `Running()` — a longops poll — as the anti-duplicate guard. But `execute` ran `zfs snapshot` (up to 60 s) BEFORE `ops.Start()`. During that entire window `Running()` returned false, so a concurrent tick or manual RunNow could launch a second `execute` goroutine.

**Fix**: replaced with `TryAcquire`/`Release` — an atomic `inFlight` map that reserves the job slot before the snapshot and releases it in `defer`. The slot is taken the moment `RunNow`/`check` decides to launch — zero window.

**Tests** (under `-race`):
- `TestRunnerTryAcquireRelease`: atomicity of the slot (3 cases)
- `TestRunNowPreventsDoubleExecution`: concurrent RunNow calls, second gets `ErrAlreadyRunning`, slot freed after completion

**Deployed** in citadel-01 and citadel-02 (NRestarts=0, no panics). Demo pending (VPS SSH down).