### PR TITLE
fix(longops): kill process group on cancel, not just the leader

### DIFF
--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -164,7 +165,9 @@ func NewCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 		args = append([]string{"-n", name}, args...)
 		name = "sudo"
 	}
-	return exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
 }
 
 // trimErr recorta stderr para mensajes de error legibles (máx. 200 chars).

--- a/internal/longops/longops.go
+++ b/internal/longops/longops.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os/exec"
 	"sync"
+	"syscall"
 	"time"
 
 	"easyzfs/internal/executil"
@@ -228,6 +229,11 @@ func (m *Manager) Cancel(id string) error {
 	if cancel == nil {
 		return ErrNotRunning
 	}
+	// Matar el grupo de procesos completo (auditoría 7-Ago-2026):
+	// cancel() solo mata el líder (bash/sudo); con Setpgid=true en
+	// executil.NewCommand, Kill(-pgid) alcanza a todos los hijos del
+	// pipeline (zfs send, ssh, etc.). Ignoramos ESRCH (ya murió solo).
+	_ = syscall.Kill(-op.PID, syscall.SIGKILL)
 	cancel()
 	return nil
 }


### PR DESCRIPTION
Closes #13 (hallazgo 2.2)

`Cancel()` relied on context cancellation which sends `SIGKILL` only to the leader process (`bash`/`sudo`). Children in the pipeline (`zfs send`, `ssh`) kept running, consuming I/O and leaving the destination dataset in an inconsistent state.

**Fix**:
- `executil.NewCommand`: set `SysProcAttr.Setpgid=true` so the process and its children form a dedicated process group.
- `Manager.Cancel`: `Kill(-op.PID, SIGKILL)` the whole group before calling `cancel()`. With `sudo` in the chain (`useSudo=true`), `op.PID` is sudo's PID, which is the group leader — killing the group kills the entire pipeline.

**Deployed** in citadel-01 and citadel-02 (NRestarts=0, no regressions).