### PR TITLE
fix(security): anchor name regexes to ^[a-zA-Z0-9] — block leading dash/dot

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -32,10 +32,10 @@ var (
 
 // Whitelists de nombres (lección 6 + ejecución segura del skill).
 var (
-	rePool     = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
-	reDataset  = regexp.MustCompile(`^[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$`)
-	reSnapName = regexp.MustCompile(`^[a-zA-Z0-9_.:-]{1,128}$`)
-	reDev      = regexp.MustCompile(`^[a-zA-Z0-9_.:-]{1,64}$`) // sdb, nvme0n1, ata-XXX…
+	rePool     = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$`)
+	reDataset  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*(/[a-zA-Z0-9][a-zA-Z0-9_.-]*)*$`)
+	reSnapName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$`)
+	reDev      = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,63}$`) // sdb, nvme0n1, ata-XXX…
 )
 
 // ValidTopos — topologías admitidas al crear/añadir vdevs.

--- a/internal/replication/replication.go
+++ b/internal/replication/replication.go
@@ -48,9 +48,9 @@ type Job struct {
 // Whitelists estrictas: lo que toca el shell del pipeline send|recv.
 // Cualquier cosa fuera del patrón se rechaza ANTES de construir el comando.
 var (
-	reDataset = regexp.MustCompile(`^[a-zA-Z0-9_.\-/]+$`)
+	reDataset = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$`)
 	reSSHUser = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	reSSHHost = regexp.MustCompile(`^[a-zA-Z0-9.\-]+$`)
+	reSSHHost = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.\-]*$`)
 )
 
 // ValidateDataset — nombre de dataset/pool (sin espacios ni metacaracteres).

--- a/internal/replication/replication_test.go
+++ b/internal/replication/replication_test.go
@@ -30,6 +30,8 @@ func TestValidateDataset(t *testing.T) {
 		"", "pool/x; rm -rf /", "pool/x`id`", "pool/x y", "pool/$(id)",
 		"pool/x|cat", "pool/x&reboot", "pool/x>f", "pool/x<f", "pool/x\"q",
 		"pool/x'q", "pool/x\\n", "pool/x#bm", "pool/x@snap", "pool/x:80",
+		// Nombres que empiezan por - o . = option injection (hallazgo 2.3)
+		"-p", ".dot", "-pool/x", ".pool/x",
 	}
 	for _, s := range bad {
 		if err := ValidateDataset(s); err == nil {
@@ -55,6 +57,12 @@ func TestValidateSSHCreds(t *testing.T) {
 	}
 	if err := ValidateSSHHost("nas.lan-1.example.com"); err != nil {
 		t.Errorf("host válido rechazado: %v", err)
+	}
+	// Hosts que empiezan por - o . = option injection.
+	for _, h := range []string{"-oForwardAgent=yes", ".lan"} {
+		if err := ValidateSSHHost(h); err == nil {
+			t.Errorf("host %q con leading dash/dot debería rechazarse", h)
+		}
 	}
 	for _, p := range []int{0, -1, 65536, 99999} {
 		if err := ValidateSSHPort(p); err == nil {


### PR DESCRIPTION
Closes #13 (hallazgo 2.3)

Whitelists for pool/dataset/snapshot/device names and SSH hosts allowed `-` or `.` as the first character. A name like `-X` slipped past validation and was interpreted as a flag of `zpool`/`zfs`.

Not exploitable as shell injection (charset excludes spaces, `;`, `|`, `$`, quotes, backticks) and all mutations require admin, but the whitelist was incorrect — a valid ZFS name never starts with `-` or `.`.

**Fix**: anchored all six regexes to `^[a-zA-Z0-9]`:
- `actions`: `rePool`, `reDataset`, `reSnapName`, `reDev`
- `replication`: `reDataset`, `reSSHHost` (`reSSHUser` already anchored to `^[a-z_]`)

**Tests**: leading dash/dot cases in `TestValidateDataset` and `TestValidateSSHCreds`.

**Deployed** in citadel-01 and citadel-02 (NRestarts=0).