### PR TITLE
feat: CI workflow, hub/auth tests, go.mod fix, Store.Get optimization (P4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - run: go vet ./...
+      - run: go test -race ./...
+
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - uses: dominikh/staticcheck-action@v1.3
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.24'
 
       - uses: actions/setup-node@v4
         with:

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"easyzfs/internal/db"
+)
+
+func nuevoManager(t *testing.T) *Manager {
+	t.Helper()
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = d.Exec(`INSERT OR IGNORE INTO users(user, role, pass_hash) VALUES ('admin','admin','x')`)
+	_, _ = d.Exec(`INSERT OR IGNORE INTO users(user, role, pass_hash) VALUES ('user1','user','x')`)
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatal(err)
+	}
+	return &Manager{db: d, secret: secret}
+}
+
+func parseCookieToken(v string) (token string) {
+	token, _, _ = strings.Cut(v, "|")
+	return token
+}
+
+func TestCreateAndValidateSession(t *testing.T) {
+	m := nuevoManager(t)
+	cookie, err := m.CreateSession(context.Background(), "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cookie.HttpOnly {
+		t.Error("cookie debería ser HttpOnly")
+	}
+	if cookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite esperado Lax (%d), got %d", http.SameSiteLaxMode, cookie.SameSite)
+	}
+
+	user, role, ok := m.Validate(context.Background(), cookie.Value)
+	if !ok {
+		t.Fatal("sesión válida rechazada")
+	}
+	if user != "admin" || role != "admin" {
+		t.Fatalf("esperado admin/admin, got %s/%s", user, role)
+	}
+
+	// El viewer también recupera su rol
+	c2, _ := m.CreateSession(context.Background(), "user1")
+	_, role2, ok2 := m.Validate(context.Background(), c2.Value)
+	if !ok2 || role2 != "user" {
+		t.Fatalf("esperado user, got %s ok=%v", role2, ok2)
+	}
+}
+
+func TestValidateRejectsTamperedSignature(t *testing.T) {
+	m := nuevoManager(t)
+	cookie, _ := m.CreateSession(context.Background(), "admin")
+	tampered := cookie.Value[:len(cookie.Value)-4] + "xxxx"
+	_, _, ok := m.Validate(context.Background(), tampered)
+	if ok {
+		t.Error("firma alterada debería rechazarse")
+	}
+}
+
+func TestValidateRejectsExpiredSession(t *testing.T) {
+	m := nuevoManager(t)
+	cookie, err := m.CreateSession(context.Background(), "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := parseCookieToken(cookie.Value)
+	_, _ = m.db.Exec("UPDATE sessions SET expires_at=? WHERE token=?",
+		time.Now().Add(-time.Hour).UTC().Format(time.RFC3339), token)
+	_, _, ok := m.Validate(context.Background(), cookie.Value)
+	if ok {
+		t.Error("sesión expirada debería rechazarse")
+	}
+}
+
+func TestValidateRejectsBogusCookie(t *testing.T) {
+	m := nuevoManager(t)
+	for _, v := range []string{"", "sinpipe", "|", "token|mal"} {
+		_, _, ok := m.Validate(context.Background(), v)
+		if ok {
+			t.Errorf("cookie %q debería rechazarse", v)
+		}
+	}
+}
+
+func TestRoleFromContext(t *testing.T) {
+	if RoleFromContext(context.Background()) != "" {
+		t.Error("contexto vacío debería devolver ''")
+	}
+	ctx := context.WithValue(context.Background(), ctxRole, "admin")
+	if RoleFromContext(ctx) != "admin" {
+		t.Error("context con role debería devolver 'admin'")
+	}
+}
+
+func TestDestroySession(t *testing.T) {
+	m := nuevoManager(t)
+	cookie, _ := m.CreateSession(context.Background(), "admin")
+	m.DestroySession(context.Background(), cookie.Value)
+	_, _, ok := m.Validate(context.Background(), cookie.Value)
+	if ok {
+		t.Error("sesión destruida debería rechazarse")
+	}
+}
+
+func TestDestroyUserSessions(t *testing.T) {
+	m := nuevoManager(t)
+	c1, _ := m.CreateSession(context.Background(), "admin")
+	c2, _ := m.CreateSession(context.Background(), "admin")
+	t2 := parseCookieToken(c2.Value)
+
+	if err := m.DestroyUserSessions(context.Background(), "admin", t2); err != nil {
+		t.Fatal(err)
+	}
+	_, _, ok := m.Validate(context.Background(), c1.Value)
+	if ok {
+		t.Error("c1 debería estar destruida")
+	}
+	_, _, ok = m.Validate(context.Background(), c2.Value)
+	if !ok {
+		t.Error("c2 debería seguir viva")
+	}
+}
+
+func TestExpiredCookie(t *testing.T) {
+	m := nuevoManager(t)
+	c := m.ExpiredCookie()
+	if c.MaxAge != -1 {
+		t.Errorf("ExpiredCookie MaxAge esperado -1, got %d", c.MaxAge)
+	}
+}
+
+func TestPurgeExpired(t *testing.T) {
+	m := nuevoManager(t)
+	c1, _ := m.CreateSession(context.Background(), "admin")
+	token := parseCookieToken(c1.Value)
+	_, _ = m.db.Exec("UPDATE sessions SET expires_at=? WHERE token=?",
+		time.Now().Add(-time.Hour).UTC().Format(time.RFC3339), token)
+	if err := m.PurgeExpired(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	_, _, ok := m.Validate(context.Background(), c1.Value)
+	if ok {
+		t.Error("sesión expirada debería haberse purgado")
+	}
+}
+
+func TestSignDeterministic(t *testing.T) {
+	m := nuevoManager(t)
+	s1 := m.sign("abc")
+	s2 := m.sign("abc")
+	if s1 != s2 {
+		t.Error("sign debería ser determinista")
+	}
+	if s1 == m.sign("abcd") {
+		t.Error("tokens distintos deberían tener firmas distintas")
+	}
+	if len(s1) != 64 {
+		t.Errorf("firma esperada 64 hex chars, got %d", len(s1))
+	}
+	if _, err := hex.DecodeString(s1); err != nil {
+		t.Errorf("firma no es hex válido: %v", err)
+	}
+}
+
+func TestTokenRandomness(t *testing.T) {
+	m := nuevoManager(t)
+	c1, _ := m.CreateSession(context.Background(), "admin")
+	c2, _ := m.CreateSession(context.Background(), "user1")
+	t1 := parseCookieToken(c1.Value)
+	t2 := parseCookieToken(c2.Value)
+	if t1 == t2 {
+		t.Error("tokens deberían ser únicos")
+	}
+	if len(t1) != 64 {
+		t.Errorf("token esperado 64 hex chars, got %d", len(t1))
+	}
+}

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -1,0 +1,153 @@
+package hub
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHubSubscribePublish(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe("user1")
+	defer h.Close()
+
+	go h.Publish("test", map[string]string{"k": "v"})
+
+	select {
+	case ev := <-ch:
+		if ev.Name != "test" {
+			t.Errorf("evento esperado 'test', got %q", ev.Name)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no se recibió el evento")
+	}
+}
+
+func TestHubPublishNoBlock(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe("u1")
+	defer h.Close()
+	// Buffer 32: Publish nunca bloquea aunque el suscriptor no lea.
+	var published atomic.Bool
+	go func() {
+		for i := 0; i < 64; i++ {
+			h.Publish("tick", i)
+		}
+		published.Store(true)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for !published.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !published.Load() {
+		t.Fatal("Publish bloqueó con buffer lleno")
+	}
+	// Consumir un evento para que no se bloquee el cierre.
+	select {
+	case <-ch:
+	default:
+	}
+}
+
+func TestHubUnsubscribe(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe("u1")
+	h.Unsubscribe(ch)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.Publish("x", nil)
+	}()
+	select {
+	case <-ch:
+		t.Error("evento recibido tras unsubscribe")
+	case <-done:
+	}
+}
+
+func TestHubCloseIdempotent(t *testing.T) {
+	h := NewHub()
+	h.Close()
+	h.Close() // sin panic
+}
+
+func TestHubCloseSignalsSubscribers(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe("u1")
+	h.Close()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("canal debería estar cerrado tras Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canal no cerrado")
+	}
+}
+
+func TestHubUserActive(t *testing.T) {
+	h := NewHub()
+	defer h.Close()
+	if h.UserActive("u1") {
+		t.Error("sin suscriptores no debería estar activo")
+	}
+	ch := h.Subscribe("u1")
+	if !h.UserActive("u1") {
+		t.Error("u1 debería estar activo")
+	}
+	h.Unsubscribe(ch)
+	if h.UserActive("u1") {
+		t.Error("tras unsubscribe no debería estar activo")
+	}
+}
+
+func TestHubConcurrentSubPublishUnsubClose(t *testing.T) {
+	h := NewHub()
+	var wg sync.WaitGroup
+	const n = 20
+	channels := make([]chan Event, n)
+
+	// Suscribir concurrentemente
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			channels[i] = h.Subscribe("")
+		}(i)
+	}
+	wg.Wait()
+
+	// Publicar y desuscribir concurrentemente
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				h.Publish("ev", j)
+			}
+		}(i)
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h.Unsubscribe(channels[i])
+		}(i)
+	}
+	wg.Wait()
+
+	h.Close()
+
+	// Drenar canales residuales
+	for _, ch := range channels {
+		for {
+			select {
+			case <-ch:
+			default:
+				goto done
+			}
+		}
+	done:
+	}
+}

--- a/internal/replication/replication.go
+++ b/internal/replication/replication.go
@@ -158,18 +158,39 @@ func (st *Store) List(ctx context.Context) ([]Job, error) {
 	return out, rows.Err()
 }
 
-// Get devuelve un job por id.
+// Get devuelve un job por id (query directa: O(1), no List+filter).
 func (st *Store) Get(ctx context.Context, id int64) (*Job, error) {
-	jobs, err := st.List(ctx)
+	row := st.db.QueryRowContext(ctx,
+		`SELECT id, source, dest_type, dest_dataset, host, user, port,
+		        raw, force_full, schedule, enabled, last_bookmark, last_run, last_ok,
+		        last_error, created_at
+		 FROM replication_jobs WHERE id=?`, id)
+	var j Job
+	var raw, ff, en int
+	var lastRun, lastOK sql.NullString
+	var created string
+	err := row.Scan(&j.ID, &j.Source, &j.DestType, &j.DestDataset, &j.Host, &j.User,
+		&j.Port, &raw, &ff, &j.Schedule, &en, &j.LastBookmark, &lastRun, &lastOK,
+		&j.LastError, &created)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
 	if err != nil {
 		return nil, err
 	}
-	for i := range jobs {
-		if jobs[i].ID == id {
-			return &jobs[i], nil
-		}
+	j.Raw = raw != 0
+	j.ForceFull = ff != 0
+	j.Enabled = en != 0
+	if lastRun.Valid && lastRun.String != "" {
+		t := parseTS(lastRun.String)
+		j.LastRun = &t
 	}
-	return nil, ErrNotFound
+	if lastOK.Valid && lastOK.String != "" {
+		ok := lastOK.String == "1"
+		j.LastOK = &ok
+	}
+	j.CreatedAt = parseTS(created)
+	return &j, nil
 }
 
 // Create inserta un job y devuelve su id.


### PR DESCRIPTION
Closes #13

Phase P4 from the 7-Aug-2026 audit: CI quality gate + tests for untested critical packages.

**CI workflow** (`.github/workflows/ci.yml`):
- `go vet ./...` + `go test -race ./...` + staticcheck
- `tsc --noEmit` + `vite build` for the frontend
- Runs on every push/PR to main

**Hub tests** (7, under `-race`):
- Subscribe/Publish, Publish-no-block, Unsubscribe, Close-idempotent
- Close-signals-subscribers, UserActive, concurrent Subscribe/Publish/Unsubscribe/Close

**Auth tests** (11):
- Session create/validate, tampered signature rejection, expired session rejection
- Bogus cookie rejection, Destroy session, Destroy user sessions (except one)
- Expired cookie, Purge expired, sign deterministic, token randomness

**go.mod**: tidy (toolchain go1.26.5). CI workflows pin to `go 1.24` explicitly instead of the invalid `go-version-file: go.mod` (which pointed at bogus `1.25.12`).

**Store.Get**: direct `SELECT WHERE id=?` query instead of `List()` + in-memory filter (O(1) vs O(n)).

All 16 packages pass `go test -race ./...`.