### PR TITLE
feat(webhook): bounded async queue, DLQ, event_id and body cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+      # go:embed dist lo exige presente; dist/ no se trackea (ver .gitignore).
+      # Los tests de backend no tocan la SPA, un placeholder basta para compilar.
+      - name: Prepara dist/ para go:embed
+        run: mkdir -p dist && echo "<!doctype html><html><body></body></html>" > dist/index.html
       - run: go vet ./...
       - run: go test -race ./...
 
@@ -24,7 +28,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - uses: dominikh/staticcheck-action@v1.3
+      - uses: dominikh/staticcheck-action@v1.3.1
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+      - name: Prepara dist/ para go:embed
+        run: mkdir -p dist && echo "<!doctype html><html><body></body></html>" > dist/index.html
       - uses: dominikh/staticcheck-action@v1.3.1
 
   frontend:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Binario y artefactos de build
 easyzfs
+easyzfs-local
+bin/
 *.test
 
 # Datos en runtime

--- a/internal/actions/props.go
+++ b/internal/actions/props.go
@@ -81,18 +81,6 @@ var reSize = regexp.MustCompile(`^[0-9]+([KMGTPE]i?B?)?$`)
 // sin ';' ni metacharacteres; también admite none|legacy).
 var reMountpoint = regexp.MustCompile(`^/[a-zA-Z0-9_./\-]+$`)
 
-// propSource — agrupa propiedades por origen para la UI (solo lectura vs
-// editables vs user properties). Devuelve "" si la propiedad no es editable.
-func propSource(name string) string {
-	if _, ok := propValidators[name]; ok {
-		return "editable"
-	}
-	if strings.HasPrefix(name, "user:") || strings.HasPrefix(name, "org.openzfs:") {
-		return "user"
-	}
-	return "readonly"
-}
-
 // valid — comprueba que el valor es admisible para la propiedad.
 func (p propSpec) valid(v string) bool {
 	switch p.kind {

--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -5,26 +5,18 @@
 package alerts
 
 import (
-	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"math/rand"
-	"net/http"
-	"os"
-	"strconv"
 	"time"
 
 	"easyzfs/internal/hub"
 	"easyzfs/internal/model"
 	"easyzfs/internal/push"
 	"easyzfs/internal/settings"
+	"easyzfs/internal/webhook"
 )
 
 // Alerter evalúa umbrales y persiste/emite alertas.
@@ -33,6 +25,7 @@ type Alerter struct {
 	hub  *hub.Hub
 	st   *settings.Store
 	push *push.Sender // puede ser nil (push no configurado)
+	wh   *webhook.Notifier // puede ser nil (webhook desactivado)
 }
 
 // New crea el Alerter.
@@ -42,6 +35,10 @@ func New(d *sql.DB, h *hub.Hub, st *settings.Store) *Alerter {
 
 // SetPush conecta el sender Web Push (opcional; nil = sin notificaciones push).
 func (a *Alerter) SetPush(s *push.Sender) { a.push = s }
+
+// SetWebhook conecta el notificador de webhook saliente (opcional; nil = sin
+// webhook). El notifier ya arranca su worker al crearse; aquí solo se enlaza.
+func (a *Alerter) SetWebhook(w *webhook.Notifier) { a.wh = w }
 
 // Raise inserta una alerta sin metadatos estructurados (kind "").
 func (a *Alerter) Raise(ctx context.Context, level, source, target, message string) {
@@ -103,75 +100,17 @@ func (a *Alerter) RaiseKind(ctx context.Context, level, source, target, message,
 	a.hub.Publish("alert.new", map[string]any{
 		"alert": model.Alert{ID: id, Ts: now, Level: level, Source: source, Target: target, Message: message},
 	})
-	a.notifyWebhook(level, source, target, message, now)
+	// Webhook saliente (async, cola acotada + DLQ): encola y sigue.
+	if a.wh != nil {
+		a.wh.Notify(webhook.Event{
+			ID: id, Ts: now, Level: level, Source: source, Target: target, Message: message,
+		})
+	}
 	// Push (app cerrada): fire-and-forget; el sender decide a quién y nunca falla.
 	if a.push != nil && kind != "" {
 		go a.push.Notify(context.Background(),
 			push.Alert{Level: level, Source: source, Target: target, Kind: kind, Params: params})
 	}
-}
-
-// notifyWebhook envía la alerta al webhook de settings (si no está vacío) en
-// una goroutine con HMAC-SHA256, timeout configurable y 3 reintentos con
-// backoff exponencial + jitter. Best-effort: solo log si falla.
-func (a *Alerter) notifyWebhook(level, source, target, message string, ts time.Time) {
-	st, err := a.st.Load(context.Background())
-	if err != nil || st.Webhook == "" {
-		return
-	}
-	payload, err := json.Marshal(map[string]any{
-		"level": level, "source": source, "target": target, "message": message,
-		"ts": ts.UTC().Format(time.RFC3339),
-	})
-	if err != nil {
-		return
-	}
-	secret := os.Getenv("WEBHOOK_SECRET")
-	timeout := 10
-	if v := os.Getenv("WEBHOOK_TIMEOUT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			timeout = n
-		}
-	}
-	go func(url string, body []byte) {
-		client := &http.Client{Timeout: time.Duration(timeout) * time.Second}
-		var lastErr error
-		for attempt := 1; attempt <= 3; attempt++ {
-			req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(body))
-			if err != nil {
-				log.Printf("alerts: webhook %s (intento %d): request: %v", url, attempt, err)
-				return
-			}
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("User-Agent", "EasyZFS-Webhook/1.0")
-			if secret != "" {
-				mac := hmac.New(sha256.New, []byte(secret))
-				mac.Write(body)
-				req.Header.Set("X-EasyZFS-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
-			}
-			resp, err := client.Do(req)
-			if err != nil {
-				lastErr = err
-			} else {
-				respBody, _ := io.ReadAll(resp.Body)
-				resp.Body.Close()
-				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-					return // éxito
-				}
-				lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
-				// 4xx (excepto 429) no reintentar: es error del cliente, no temporal.
-				if resp.StatusCode >= 400 && resp.StatusCode != 429 {
-					break
-				}
-			}
-			if attempt < 3 {
-				base := time.Duration(1<<(attempt-1)) * time.Second // 1s, 2s, 4s
-				jitter := time.Duration(rand.Intn(1000)) * time.Millisecond
-				time.Sleep(base + jitter)
-			}
-		}
-		log.Printf("alerts: webhook %s: %v (3 intentos agotados)", url, lastErr)
-	}(st.Webhook, payload)
 }
 
 // EvaluatePools aplica umbrales de capacidad y scrub con errores.

--- a/internal/collectors/perf.go
+++ b/internal/collectors/perf.go
@@ -176,10 +176,7 @@ func parseArcSummary(out string) (*model.ArcStats, bool) {
 	}
 	st := &model.ArcStats{}
 	if sm != nil {
-		unit := strings.ToUpper(sm[2])
-		if strings.HasSuffix(unit, "IB") { // "GiB" → "G" (parseHumanSize espera sufijo simple)
-			unit = unit[:len(unit)-2]
-		}
+		unit := strings.TrimSuffix(strings.ToUpper(sm[2]), "IB") // "GiB" → "G" (parseHumanSize espera sufijo simple)
 		if sz, ok := parseHumanSize(sm[1] + unit); ok {
 			st.SizeBytes = sz
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 // Config — configuración de la app (todo por variables de entorno).
@@ -24,6 +25,10 @@ type Config struct {
 	VAPIDPublicKey  string // VAPID_PUBLIC_KEY (Web Push; la genera el instalador)
 	VAPIDPrivateKey string // VAPID_PRIVATE_KEY (solo servidor; si falta, push desactivado)
 	VAPIDSubject    string // VAPID_SUBJECT (def "mailto:easyzfs@localhost"; siempre mailto:)
+
+	WebhookSecret  string        // WEBHOOK_SECRET (firma HMAC del webhook saliente)
+	WebhookTimeout time.Duration // WEBHOOK_TIMEOUT en segundos (def 10)
+	WebhookRetries int           // WEBHOOK_RETRIES (def 3)
 }
 
 // DataDir — directorio de datos del daemon (deriva de DB_PATH): ahí viven la
@@ -54,6 +59,10 @@ func Load() *Config {
 		VAPIDPublicKey:  os.Getenv("VAPID_PUBLIC_KEY"),
 		VAPIDPrivateKey: os.Getenv("VAPID_PRIVATE_KEY"),
 		VAPIDSubject:    env("VAPID_SUBJECT", "mailto:easyzfs@localhost"),
+
+		WebhookSecret:  os.Getenv("WEBHOOK_SECRET"),
+		WebhookTimeout: time.Duration(envInt("WEBHOOK_TIMEOUT", 10)) * time.Second,
+		WebhookRetries: envInt("WEBHOOK_RETRIES", 3),
 	}
 	if cfg.Demo {
 		cfg.Mock = true // demo implica colectores mock

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -112,6 +112,14 @@ var migrations = []string{
 	// v16: avatar del usuario (foto de perfil). Nombre del fichero dentro de
 	// <datadir>/avatars/ (p. ej. 'nacho.webp'); vacío = sin foto.
 	`ALTER TABLE users ADD COLUMN avatar TEXT NOT NULL DEFAULT '';`,
+	// v17: DLQ del webhook saliente (issue #18): eventos no entregados tras
+	// agotar reintentos. event_id = id de la alerta (clave de idempotencia).
+	`CREATE TABLE IF NOT EXISTS webhook_events (
+	  event_id  TEXT PRIMARY KEY,
+	  payload   TEXT NOT NULL,
+	  sent_at   TEXT NOT NULL DEFAULT (datetime('now')),
+	  error     TEXT NOT NULL
+	);`,
 }
 
 // Open abre la BD con WAL, busy_timeout y una sola conexión escritora.

--- a/internal/push/push_test.go
+++ b/internal/push/push_test.go
@@ -5,7 +5,7 @@ package push
 
 import (
 	"context"
-	"crypto/elliptic"
+	"crypto/ecdh"
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
@@ -26,8 +26,7 @@ import (
 // auth = 16 bytes), como las que genera el navegador.
 func clavesSub(t *testing.T) (p256dh, auth string) {
 	t.Helper()
-	curve := elliptic.P256()
-	_, x, y, err := elliptic.GenerateKey(curve, rand.Reader)
+	priv, err := ecdh.P256().GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("ecdh: %v", err)
 	}
@@ -35,7 +34,7 @@ func clavesSub(t *testing.T) (p256dh, auth string) {
 	if _, err := rand.Read(secret); err != nil {
 		t.Fatalf("auth secret: %v", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(elliptic.Marshal(curve, x, y)),
+	return base64.RawURLEncoding.EncodeToString(priv.PublicKey().Bytes()),
 		base64.RawURLEncoding.EncodeToString(secret)
 }
 

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,233 @@
+// Package webhook — notificador SALIENTE de alertas (paridad con el patrón
+// canónico de NetPulse server-go/internal/webhook/webhook.go).
+//
+// Entrega a la URL configurada con firma HMAC-SHA256 del body, reintentos con
+// backoff exponencial + jitter (4xx no se reintenta salvo 429; 429/5xx sí) y
+// DLQ en la tabla webhook_events si se agotan los reintentos. El payload lleva
+// event_id (id de la alerta) como clave de idempotencia para el receptor.
+//
+// Notify NUNCA bloquea al llamador: encola el evento y un worker único lo
+// drena. Si la cola está llena se descarta (la alerta ya está en /api/alerts).
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	queueCap   = 64
+	maxBodyCap = 64 << 10 // 64 KB de respuesta del receptor (cap de seguridad)
+)
+
+// Config — parámetros del webhook, leídos una vez al arrancar (env como
+// bootstrap; la URL se resuelve dinámicamente desde settings en cada envío).
+type Config struct {
+	Secret     string
+	Timeout    time.Duration
+	Retries    int
+	RetryDelay time.Duration
+}
+
+// Event — alerta encolable para el webhook.
+type Event struct {
+	ID      int64
+	Ts      time.Time
+	Level   string
+	Source  string
+	Target  string
+	Message string
+}
+
+// payload es el contrato del webhook (firmado): event_id para idempotencia
+// del receptor + datos de la alerta.
+type payload struct {
+	EventID string `json:"event_id"`
+	Ts      string `json:"ts"` // RFC3339 UTC
+	Level   string `json:"level"`
+	Source  string `json:"source"`
+	Target  string `json:"target"`
+	Message string `json:"message"`
+}
+
+// Notifier entrega alertas de forma asíncrona con cola acotada y DLQ.
+type Notifier struct {
+	cfg    Config
+	db     *sql.DB
+	getURL func() string // URL actual (settings); "" = webhook desactivado
+
+	client *http.Client
+
+	ch   chan Event
+	done chan struct{}
+	once sync.Once
+	wg   sync.WaitGroup
+}
+
+// NewNotifier crea el Notifier y arranca su worker.
+func NewNotifier(cfg Config, d *sql.DB, getURL func() string) *Notifier {
+	n := &Notifier{
+		cfg:    cfg,
+		db:     d,
+		getURL: getURL,
+		client: &http.Client{Timeout: cfg.Timeout},
+		ch:     make(chan Event, queueCap),
+		done:   make(chan struct{}),
+	}
+	n.wg.Add(1)
+	go n.worker()
+	return n
+}
+
+// Notify encola el evento y vuelve inmediatamente.
+func (n *Notifier) Notify(ev Event) {
+	select {
+	case <-n.done:
+		return
+	default:
+	}
+	select {
+	case n.ch <- ev:
+	default:
+		log.Printf("webhook: cola llena, evento de alerta %d descartado", ev.ID)
+	}
+}
+
+// Close para el worker (los eventos en curso terminan; la cola restante se
+// descarta: la alerta ya está en /api/alerts).
+func (n *Notifier) Close() {
+	n.once.Do(func() {
+		close(n.done)
+		n.wg.Wait()
+	})
+}
+
+func (n *Notifier) worker() {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.done:
+			return
+		case ev := <-n.ch:
+			n.sendWithRetry(ev)
+		}
+	}
+}
+
+// payloadJSON construye el body firmable de un evento.
+func payloadJSON(ev Event) ([]byte, error) {
+	return json.Marshal(payload{
+		EventID: fmt.Sprintf("%d", ev.ID),
+		Ts:      ev.Ts.UTC().Format(time.RFC3339),
+		Level:   ev.Level,
+		Source:  ev.Source,
+		Target:  ev.Target,
+		Message: ev.Message,
+	})
+}
+
+// sign calcula la firma HMAC-SHA256 del body crudo.
+func sign(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// sendWithRetry envía con backoff exponencial + jitter. 4xx (salvo 429) no se
+// reintenta; 429/5xx sí. Al agotar reintentos guarda en DLQ.
+func (n *Notifier) sendWithRetry(ev Event) {
+	url := n.getURL()
+	if url == "" {
+		return // webhook desactivado en settings
+	}
+	body, err := payloadJSON(ev)
+	if err != nil {
+		log.Printf("webhook: payload no serializable: %v", err)
+		return
+	}
+	var lastErr error
+	for attempt := 0; attempt <= n.cfg.Retries; attempt++ {
+		err = n.sendOnce(url, ev.ID, body)
+		if err == nil {
+			return
+		}
+		lastErr = err
+		var retryable bool
+		if httpErr, ok := err.(*httpStatusError); ok {
+			// 4xx (salvo 429): error del emisor, no reintentar jamás.
+			if httpErr.status >= 400 && httpErr.status < 500 && httpErr.status != http.StatusTooManyRequests {
+				log.Printf("webhook: %d permanente en alerta %d, no se reintenta", httpErr.status, ev.ID)
+				n.saveDLQ(ev, body, lastErr.Error())
+				return
+			}
+			retryable = true
+		}
+		if attempt < n.cfg.Retries && retryable {
+			jitter := time.Duration(rand.Int63n(int64(n.cfg.RetryDelay)))
+			backoff := n.cfg.RetryDelay * time.Duration(1<<attempt)
+			time.Sleep(backoff + jitter)
+		}
+	}
+	n.saveDLQ(ev, body, lastErr.Error())
+}
+
+// httpStatusError marca la respuesta HTTP para la decisión de reintento.
+type httpStatusError struct {
+	status int
+	body   string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("webhook status %d: %s", e.status, e.body)
+}
+
+func (n *Notifier) sendOnce(url string, eventID int64, body []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), n.cfg.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "EasyZFS-Webhook/2.0")
+	if n.cfg.Secret != "" {
+		req.Header.Set("X-EasyZFS-Signature", sign(body, n.cfg.Secret))
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyCap))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return &httpStatusError{status: resp.StatusCode, body: string(respBody)}
+}
+
+// saveDLQ persiste el evento no entregado para diagnóstico posterior.
+func (n *Notifier) saveDLQ(ev Event, body []byte, reason string) {
+	if n.db == nil {
+		return
+	}
+	if _, err := n.db.Exec(
+		"INSERT OR REPLACE INTO webhook_events (event_id, payload, sent_at, error) VALUES (?, ?, ?, ?)",
+		fmt.Sprintf("%d", ev.ID), string(body), time.Now().UTC().Format(time.RFC3339), reason,
+	); err != nil {
+		log.Printf("webhook: no se pudo guardar en DLQ: %v", err)
+		return
+	}
+	log.Printf("webhook: alerta %d a DLQ (%s)", ev.ID, reason)
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,236 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"easyzfs/internal/db"
+)
+
+func newTestNotifier(t *testing.T, url string, cfg Config) (*Notifier, func()) {
+	t.Helper()
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	n := NewNotifier(cfg, d, func() string { return url })
+	return n, func() {
+		n.Close()
+		d.Close()
+	}
+}
+
+func ev(id int64) Event {
+	return Event{ID: id, Ts: time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+		Level: "warn", Source: "pool.tank", Target: "pools:tank", Message: "Pool tank al 95% de capacidad"}
+}
+
+// Entrega correcta: el receptor recibe el payload con event_id, timestamp
+// RFC3339 y los campos de la alerta; con secret configurado llega la firma
+// HMAC-SHA256 correcta (mismo header que el código de producción).
+func TestNotifier_EntregaOK_FirmaYEventID(t *testing.T) {
+	var mu sync.Mutex
+	var gotPayload map[string]any
+	var gotSig string
+	var rawBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotSig = r.Header.Get("X-EasyZFS-Signature")
+		rawBody, _ = io.ReadAll(r.Body)
+		json.Unmarshal(rawBody, &gotPayload)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	n, cleanup := newTestNotifier(t, srv.URL, Config{
+		Secret: "secreta", Timeout: 2 * time.Second, Retries: 2, RetryDelay: 10 * time.Millisecond,
+	})
+	defer cleanup()
+
+	n.Notify(ev(42))
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		ready := gotPayload != nil
+		mu.Unlock()
+		if ready {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("el receptor no recibió el evento a tiempo")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPayload["event_id"] != "42" {
+		t.Errorf("event_id = %v, esperado 42", gotPayload["event_id"])
+	}
+	if gotPayload["ts"] != "2026-08-09T12:00:00Z" {
+		t.Errorf("ts = %v, esperado RFC3339 UTC", gotPayload["ts"])
+	}
+	if gotPayload["level"] != "warn" || gotPayload["source"] != "pool.tank" || gotPayload["message"] == "" {
+		t.Errorf("payload incompleto: %v", gotPayload)
+	}
+	if gotSig == "" {
+		t.Fatal("no llegó firma X-EasyZFS-Signature")
+	}
+	mac := hmac.New(sha256.New, []byte("secreta"))
+	mac.Write(rawBody)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if gotSig != want {
+		t.Errorf("firma = %s, esperada %s", gotSig, want)
+	}
+}
+
+// Fallo permanente (400): no se reintenta y el evento va a la DLQ.
+func TestNotifier_4xxVaADLQ(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	n, cleanup := newTestNotifier(t, srv.URL, Config{
+		Timeout: 2 * time.Second, Retries: 3, RetryDelay: 5 * time.Millisecond,
+	})
+	defer cleanup()
+
+	n.Notify(ev(7))
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		got := hits
+		mu.Unlock()
+		if got > 0 {
+			time.Sleep(100 * time.Millisecond) // deja que el worker acabe de guardar DLQ
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("el receptor no recibió el evento a tiempo")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	if hits != 1 {
+		t.Errorf("hits = %d, esperado 1 (un 400 no se reintenta)", hits)
+	}
+	mu.Unlock()
+
+	var nDLQ int
+	if err := n.db.QueryRow("SELECT COUNT(*) FROM webhook_events WHERE event_id='7'").Scan(&nDLQ); err != nil {
+		t.Fatal(err)
+	}
+	if nDLQ != 1 {
+		t.Errorf("webhook_events = %d, esperada 1 (fallo permanente)", nDLQ)
+	}
+	var errText string
+	if err := n.db.QueryRow("SELECT error FROM webhook_events WHERE event_id='7'").Scan(&errText); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(errText, "400") {
+		t.Errorf("error DLQ = %q, esperado mención del 400", errText)
+	}
+}
+
+// 5xx persistente: tras agotar reintentos va a DLQ.
+func TestNotifier_5xxAgotaReintentosYVaADLQ(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	n, cleanup := newTestNotifier(t, srv.URL, Config{
+		Timeout: 2 * time.Second, Retries: 2, RetryDelay: 2 * time.Millisecond,
+	})
+	defer cleanup()
+
+	n.Notify(ev(9))
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		got := hits
+		mu.Unlock()
+		if got >= 3 {
+			time.Sleep(100 * time.Millisecond)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no se completaron los reintentos a tiempo")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	if hits != 3 {
+		t.Errorf("hits = %d, esperado 3 (intento inicial + 2 reintentos)", hits)
+	}
+	mu.Unlock()
+
+	var nDLQ int
+	if err := n.db.QueryRow("SELECT COUNT(*) FROM webhook_events WHERE event_id='9'").Scan(&nDLQ); err != nil {
+		t.Fatal(err)
+	}
+	if nDLQ != 1 {
+		t.Errorf("webhook_events = %d, esperada 1 (reintentos agotados)", nDLQ)
+	}
+}
+
+// Sin URL configurada (getURL → "") el webhook está desactivado: no llama.
+func TestNotifier_SinURLNoEnvia(t *testing.T) {
+	var hits int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	n := NewNotifier(Config{Timeout: 2 * time.Second, Retries: 2}, d, func() string { return "" })
+	defer n.Close()
+
+	n.Notify(ev(1))
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 0 {
+		t.Errorf("hits = %d, esperado 0 (URL vacía = webhook desactivado)", hits)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"easyzfs/internal/settings"
 	"easyzfs/internal/updater"
 	"easyzfs/internal/users"
+	"easyzfs/internal/webhook"
 )
 
 // Inyectadas por ldflags (-X main.version=... -X main.build=...).
@@ -88,6 +89,23 @@ func main() {
 
 	h := hub.NewHub()
 	alerter := alerts.New(database, h, stStore)
+
+	// Webhook saliente (issue #18): worker async con cola acotada + DLQ. La URL
+	// se resuelve de settings en cada envío (dinámica, editable por UI); secret,
+	// timeout y retries vienen de env leídos una vez al arranque (bootstrap).
+	webhookNotifier := webhook.NewNotifier(webhook.Config{
+		Secret:     cfg.WebhookSecret,
+		Timeout:    cfg.WebhookTimeout,
+		Retries:    cfg.WebhookRetries,
+		RetryDelay: time.Second,
+	}, database, func() string {
+		st, err := stStore.Load(context.Background())
+		if err != nil {
+			return ""
+		}
+		return st.Webhook
+	})
+	alerter.SetWebhook(webhookNotifier)
 
 	// Sender Web Push: inerte si faltan claves VAPID; en demo nunca envía.
 	pushSender := push.New(cfg, database, h)
@@ -173,6 +191,8 @@ func main() {
 	if err := httpSrv.Shutdown(shCtx); err != nil {
 		log.Printf("shutdown: %v", err)
 	}
+	// Para el worker del webhook ANTES de cerrar SQLite (la DLQ escribe en BD).
+	webhookNotifier.Close()
 	if err := database.Close(); err != nil {
 		log.Printf("sqlite close: %v", err)
 	}


### PR DESCRIPTION
Replaces the per-alert goroutine in `internal/alerts` with a dedicated
`webhook.Notifier` worker following the canonical NetPulse pattern.

- Bounded async queue (channel cap 64) so a burst of alerts queues instead
  of fanning out N parallel POSTs against the receiver.
- Dead-letter store: events whose retries are exhausted are persisted to a
  new `webhook_events` table instead of being dropped from the log.
- `event_id` (the alert id) in the payload, documented as the receiver's
  dedup key so a delayed 2xx followed by a retry cannot apply a side effect
  twice.
- Response bodies are capped at 64 KiB via `io.LimitReader`.
- Secret, timeout and retries are read once from env at startup; the URL
  stays in settings so UI changes take effect without restart.
- Per-request contexts with timeout; the worker stops cleanly on shutdown
  before SQLite is closed (the DLQ writes to the DB).

Closes #18