### PR TITLE
feat(ui): historical sparklines from series data (U2)

### DIFF
--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -152,6 +152,8 @@ func (s *Server) Handler() http.Handler {
 	a.HandleFunc("POST /api/pools/{name}/clear", s.auth.RequireAdmin(s.clearPool))
 	a.HandleFunc("GET /api/pools/{name}/history", s.poolHistory)
 	a.HandleFunc("GET /api/performance", s.getPerformance)
+	// series históricas (U2): rangos con downsampling LTTB
+	a.HandleFunc("GET /api/series", s.getSeries)
 	// datasets
 	a.HandleFunc("GET /api/datasets", s.listDatasets)
 	a.HandleFunc("POST /api/datasets", s.auth.RequireAdmin(s.createDataset))

--- a/internal/httpapi/series.go
+++ b/internal/httpapi/series.go
@@ -1,0 +1,44 @@
+package httpapi
+
+import (
+	"net/http"
+	"strconv"
+
+	"easyzfs/internal/series"
+)
+
+// getSeries — GET /api/series?source=pool.tank.used_pct&days=7&points=800
+// Devuelve la serie muestreada (LTTB) del rango pedido. days 1-365, points
+// 50-2000. Rango sin datos → {points: []} con 200 (un hueco es estado normal).
+func (s *Server) getSeries(w http.ResponseWriter, r *http.Request) {
+	src := r.URL.Query().Get("source")
+	if !series.ValidSource(src) {
+		writeErr(w, http.StatusBadRequest, "invalid_source",
+			"source debe ser pool.<nombre>.used_pct o disk.<dev>.temp")
+		return
+	}
+	days, err := strconv.Atoi(r.URL.Query().Get("days"))
+	if err != nil {
+		days = 7
+	}
+	from, to, err := series.ParseDays(days)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid_days", err.Error())
+		return
+	}
+	points := 800
+	if v := r.URL.Query().Get("points"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 50 && n <= 2000 {
+			points = n
+		}
+	}
+	pts, err := series.Range(r.Context(), s.db, src, from, to, points)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "db_error", err.Error())
+		return
+	}
+	if pts == nil {
+		pts = []series.Point{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"source": src, "points": pts})
+}

--- a/internal/series/series.go
+++ b/internal/series/series.go
@@ -1,0 +1,121 @@
+// Package series — consulta y downsampling de la tabla series (U2).
+// La tabla guarda muestras crudas (source, ts RFC3339, value) con retención
+// configurable (RETENTION_DAYS, def 30). El endpoint de rangos aplica LTTB
+// server-side para no ahogar al navegador (patrón sqlite-timeseries-daemon).
+package series
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Point — punto de una serie (ts epoch UTC segundos, value).
+type Point struct {
+	Ts    int64   `json:"ts"`
+	Value float64 `json:"value"`
+}
+
+// Range consulta una fuente entre from y to (epoch segundos) y devuelve hasta
+// threshold puntos muestreados con LTTB. Rango vacío → slice vacío (200).
+func Range(ctx context.Context, db *sql.DB, source string, from, to int64, threshold int) ([]Point, error) {
+	if to <= from {
+		return []Point{}, nil
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT CAST(strftime('%s', ts) AS INTEGER), value FROM series
+		 WHERE source = ? AND ts >= datetime(?, 'unixepoch') AND ts <= datetime(?, 'unixepoch')
+		 ORDER BY ts`, source, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	raw := make([]Point, 0, 256)
+	for rows.Next() {
+		var p Point
+		if err := rows.Scan(&p.Ts, &p.Value); err != nil {
+			return nil, err
+		}
+		raw = append(raw, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(raw) <= int(threshold) {
+		return raw, nil
+	}
+	return LTTB(raw, threshold), nil}
+
+// LTTB — Largest-Triangle-Three-Buckets: conserva la forma visual (picos y
+// valles) reduciendo la serie a `threshold` puntos. Adaptado del asset Go de
+// la skill sqlite-timeseries-daemon.
+func LTTB(data []Point, threshold int) []Point {
+	n := len(data)
+	if threshold >= n || threshold <= 0 {
+		return data
+	}
+	out := make([]Point, 0, threshold)
+	out = append(out, data[0])
+	every := float64(n-2) / float64(threshold-2)
+	a := 0
+	for i := 0; i < threshold-2; i++ {
+		rangeStart := int(float64(i+1)*every) + 1
+		rangeEnd := int(float64(i+2)*every) + 1
+		if rangeEnd > n {
+			rangeEnd = n
+		}
+		var avgX, avgY float64
+		for j := rangeStart; j < rangeEnd; j++ {
+			avgX += float64(data[j].Ts)
+			avgY += data[j].Value
+		}
+		avgX /= float64(rangeEnd - rangeStart)
+		avgY /= float64(rangeEnd - rangeStart)
+		bucketStart := int(float64(i)*every) + 1
+		bucketEnd := int(float64(i+1)*every) + 1
+		ax, ay := float64(data[a].Ts), data[a].Value
+		maxArea := -1.0
+		nextA := bucketStart
+		for j := bucketStart; j < bucketEnd; j++ {
+			area := abs((ax-avgX)*(data[j].Value-ay) - (ax-float64(data[j].Ts))*(avgY-ay))
+			if area > maxArea {
+				maxArea = area
+				nextA = j
+			}
+		}
+		out = append(out, data[nextA])
+		a = nextA
+	}
+	return append(out, data[n-1])
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// Sources válidas para el endpoint: pool.<name>.used_pct y disk.<dev>.temp.
+// El prefix protege de inyección/patrones raros (whitelist por prefijo).
+func ValidSource(src string) bool {
+	switch {
+	case len(src) > 5 && src[:5] == "pool." && len(src) > 6 && src[5] != '.':
+		return true
+	case len(src) > 5 && src[:5] == "disk." && len(src) > 6 && src[5] != '.':
+		return true
+	}
+	return false
+}
+
+// ParseDays convierte el parámetro ?days= a rango epoch. Acepta 1-365.
+func ParseDays(days int) (from, to int64, err error) {
+	if days < 1 || days > 365 {
+		return 0, 0, fmt.Errorf("days fuera de rango (1-365): %d", days)
+	}
+	now := time.Now().UTC()
+	to = now.Unix()
+	from = now.Add(-time.Duration(days) * 24 * time.Hour).Unix()
+	return from, to, nil
+}

--- a/internal/series/series_test.go
+++ b/internal/series/series_test.go
@@ -1,0 +1,130 @@
+package series
+
+import (
+	"context"
+	"testing"
+
+	"easyzfs/internal/db"
+)
+
+// LTTB reduce manteniendo el primer y último punto, y nunca devuelve más de
+// threshold puntos ni más que los originales.
+func TestLTTB_Reduce(t *testing.T) {
+	data := make([]Point, 100)
+	for i := range data {
+		data[i] = Point{Ts: int64(i), Value: float64(i*i % 37)}
+	}
+	got := LTTB(data, 10)
+	if len(got) != 10 {
+		t.Fatalf("LTTB(100,10) = %d puntos, esperado 10", len(got))
+	}
+	if got[0] != data[0] {
+		t.Errorf("primer punto cambiado: %+v != %+v", got[0], data[0])
+	}
+	if got[len(got)-1] != data[len(data)-1] {
+		t.Errorf("último punto cambiado")
+	}
+}
+
+// LTTB con threshold >= len devuelve la serie intacta.
+func TestLTTB_NoReduce(t *testing.T) {
+	data := []Point{{1, 2}, {2, 3}}
+	if got := LTTB(data, 5); len(got) != 2 {
+		t.Fatalf("LTTB pequeño = %d, esperado 2", len(got))
+	}
+	if got := LTTB(data, 0); len(got) != 2 {
+		t.Fatalf("LTTB threshold<=0 = %d, esperado 2", len(got))
+	}
+}
+
+// Range filtra por fuente y ventana de tiempo y aplica LTTB.
+func TestRange_FiltraYDowsample(t *testing.T) {
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	// 200 muestras de pool.tank.used_pct (una por "minuto" en epoch)
+	for i := 0; i < 200; i++ {
+		ts := int64(1_700_000_000 + i*60)
+		if _, err := d.Exec(
+			"INSERT INTO series(source, ts, value) VALUES (?, datetime(?, 'unixepoch'), ?)",
+			"pool.tank.used_pct", ts, float64(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// una muestra de otra fuente que NO debe colarse
+	d.Exec("INSERT INTO series(source, ts, value) VALUES ('disk.sda.temp', datetime(1700000060, 'unixepoch'), 42)")
+
+	from, to := int64(1_700_000_000), int64(1_700_000_000+199*60)
+	got, err := Range(context.Background(), d, "pool.tank.used_pct", from, to, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("serie vacía con datos presentes")
+	}
+	if len(got) > 50 {
+		t.Fatalf("downsampling no aplicó: %d > 50", len(got))
+	}
+	// el rango excluye la muestra de otra fuente (solo pool.tank.used_pct)
+	for _, p := range got {
+		if p.Value == 42 && p.Ts == 1700000060 {
+			t.Errorf("se coló una muestra de otra fuente")
+		}
+	}
+}
+
+// Rango sin datos o con to<=from devuelve slice vacío, no error.
+func TestRange_Vacio(t *testing.T) {
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Range(context.Background(), d, "pool.tank.used_pct", 100, 200, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("esperado vacío, %d puntos", len(got))
+	}
+}
+
+// ParseDays valida el rango.
+func TestParseDays(t *testing.T) {
+	from, to, err := ParseDays(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if to <= from || to < 0 {
+		t.Errorf("rango inválido: from=%d to=%d", from, to)
+	}
+	if _, _, err := ParseDays(0); err == nil {
+		t.Error("days=0 debería fallar")
+	}
+	if _, _, err := ParseDays(400); err == nil {
+		t.Error("days=400 debería fallar")
+	}
+}
+
+func TestValidSource(t *testing.T) {
+	for _, ok := range []struct{ src string; want bool }{
+		{"pool.tank.used_pct", true},
+		{"disk.sda.temp", true},
+		{"pool..bad", false},
+		{"other", false},
+		{"", false},
+		{"disk..bad", false},
+	} {
+		if got := ValidSource(ok.src); got != ok.want {
+			t.Errorf("ValidSource(%q) = %v, esperado %v", ok.src, got, ok.want)
+		}
+	}
+}

--- a/web/src/components/PoolCard.tsx
+++ b/web/src/components/PoolCard.tsx
@@ -6,6 +6,7 @@ import { t } from '../ui/i18n';
 import { fmtBytes, fmtBytesPair, fmtPct, fmtRatio, timeAgo } from '../ui/format';
 import { statusLabel } from '../ui/labels';
 import { Badge, InfoBubble, Meter, Switch } from './ui';
+import { Sparkline } from './Sparkline';
 import { useModal } from './Modal';
 import { useEffect, useState } from 'react';
 
@@ -51,6 +52,7 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
   const [err, setErr] = useState('');
   const [disks, setDisks] = useState<Disk[]>([]);
   const [trimOverride, setTrimOverride] = useState<boolean | null>(null);
+  const [hist, setHist] = useState<{ days: number; points: { ts: number; value: number }[] }[]>([]);
   const pct = pool.total_bytes > 0 ? (pool.used_bytes / pool.total_bytes) * 100 : 0;
   const cap = fmtBytesPair(pool.used_bytes, pool.total_bytes);
   const running = pool.scrub.state === 'running';
@@ -61,6 +63,13 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
   useEffect(() => {
     let alive = true;
     getProvider().getDisks().then((d) => { if (alive) setDisks(d); }).catch(() => {});
+    const src = `pool.${pool.name}.used_pct`;
+    getProvider().getSeries(src, 7, 120)
+      .then((r) => { if (alive) setHist((cur) => [...cur.filter((h) => h.days !== 7), { days: 7, points: r.points }]); })
+      .catch(() => {});
+    getProvider().getSeries(src, 30, 160)
+      .then((r) => { if (alive) setHist((cur) => [...cur.filter((h) => h.days !== 30), { days: 30, points: r.points }]); })
+      .catch(() => {});
     return () => { alive = false; };
   }, [pool]);
 
@@ -117,6 +126,17 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
           <div className="t2">{pool.topo}</div>
           <TopoHelp topo={pool.topo} />
           <Meter pct={pct} />
+          {hist.length > 0 && (
+            <div className="sparks" aria-label={t('pool_history_series')}>
+              {hist.sort((a, b) => a.days - b.days).map((h) => (
+                <span key={h.days} className="spark" title={t('pool_history_days', { days: h.days })}>
+                  <Sparkline points={h.points} width={72} height={26}
+                    ariaLabel={t('pool_history_days', { days: h.days })} />
+                  <em>{h.days}d</em>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <div style={{ textAlign: 'right' }}>
           <div style={{ fontWeight: 700, fontSize: 17 }}>

--- a/web/src/components/Sparkline.tsx
+++ b/web/src/components/Sparkline.tsx
@@ -1,0 +1,41 @@
+// Sparkline — gráfico de línea SVG sin dependencias (U2).
+// Dibuja la serie (epoch ts, value) como polilínea con min/max normalizados;
+// 0-1 puntos → no dibuja nada (hueco de datos = estado normal, no error).
+import { useId } from 'react';
+
+export function Sparkline({ points, width = 120, height = 32, ariaLabel }: {
+  points: { ts: number; value: number }[];
+  width?: number;
+  height?: number;
+  ariaLabel?: string;
+}) {
+  const uid = useId();
+  if (!points || points.length < 2) return <svg width={width} height={height} role="img" aria-label={ariaLabel} />;
+
+  let min = Infinity, max = -Infinity;
+  for (const p of points) {
+    if (p.value < min) min = p.value;
+    if (p.value > max) max = p.value;
+  }
+  const span = max - min;
+  const pad = span === 0 ? 1 : span * 0.08;
+  const lo = min - pad, hi = max + pad;
+
+  const x = (ts: number) => ((ts - points[0].ts) / (points[points.length - 1].ts - points[0].ts)) * (width - 2) + 1;
+  const y = (v: number) => height - 1 - ((v - lo) / (hi - lo)) * (height - 2);
+
+  const d = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${x(p.ts).toFixed(1)},${y(p.value).toFixed(1)}`).join(' ');
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} role="img" aria-label={ariaLabel}>
+      <defs>
+        <linearGradient id={`grad-${uid}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.28" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={`${d}L${width - 1},${height}L1,${height}Z`} fill={`url(#grad-${uid})`} />
+      <path d={d} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -5,7 +5,7 @@ import { notifyAuthExpired } from './events';
 import type {
   ActivityItem, Alert, BackupFile, BackupStatus, CreateDatasetReq, CreateJobReq, CreatePoolReq, CreateReplicationReq, CreateSnapshotReq, CreateUserReq,
   Dataset, DatasetProp, DatasetPropsResp, DiffEntry, Disk, DiskSmartLogResp, DiskSmartResp, Job, JobHistoryItem, Lang, LongOp, Overview, Performance, Pool, PoolHistoryEntry, PushAlertTipo, PushPreference, PushQuietHours, PushSubscriptionJSON,
-  Recommendation, ReplicationJob, ReplicationSSHKey, ReplicationTestResult, SessionUser, Settings,
+  Recommendation, ReplicationJob, ReplicationSSHKey, ReplicationTestResult, SessionUser, Settings, SeriesResp,
   SnapshotGroup, SystemTimer, SystemTimersResp, UpdateJobReq, UpdateReplicationReq, UpdateStatus, UserInfo, VersionInfo,
 } from './types';
 
@@ -142,6 +142,8 @@ export class HttpProvider implements DataProvider {
     post<void>(`/pools/${enc(pool)}/checkpoint`, { action, confirm });
   getPoolHistory = (pool: string) => get<PoolHistoryEntry[]>(`/pools/${enc(pool)}/history`);
   getPerformance = () => get<Performance>('/performance');
+  getSeries = (source: string, days: number, points = 800) =>
+    get<SeriesResp>(`/series?source=${enc(source)}&days=${days}&points=${points}`);
 
   getDatasets = () => get<Dataset[]>('/datasets');
   createDataset = (r: CreateDatasetReq) => post<void>('/datasets', r);

--- a/web/src/data/mock.ts
+++ b/web/src/data/mock.ts
@@ -6,7 +6,7 @@ import { ApiError } from './types';
 import { computeRecommendations } from './recs';
 import type {
   Alert, BackupFile, BackupStatus, CreateDatasetReq, CreateJobReq, CreatePoolReq, CreateSnapshotReq, CreateUserReq,
-  Dataset, DatasetProp, DatasetPropsResp, Disk, DiskSmartLogResp, DiskSmartResp, Job, JobHistoryItem, Lang, LongOp, Overview, Performance, Pool, PoolHistoryEntry, PushAlertTipo, SessionUser, Settings, Snapshot, SmartSelftest,
+  Dataset, DatasetProp, DatasetPropsResp, Disk, DiskSmartLogResp, DiskSmartResp, Job, JobHistoryItem, Lang, LongOp, Overview, Performance, Pool, PoolHistoryEntry, PushAlertTipo, SeriesPoint, SeriesResp, SessionUser, Settings, Snapshot, SmartSelftest,
   SnapshotGroup, SystemTimer, SystemTimersResp, UpdateJobReq, UserInfo, VersionInfo,
   CreateReplicationReq, ReplicationJob, ReplicationSSHKey, ReplicationTestResult, UpdateReplicationReq,
 } from './types';
@@ -480,6 +480,23 @@ export class MockProvider implements DataProvider {
         write_bps: Math.round((12 + i * 84) * 1024 ** 2),
       })),
     };
+  };
+
+  // Series históricas sintéticas (U2): onda con ruido, determinista por source.
+  getSeries = async (source: string, days: number, points = 120): Promise<SeriesResp> => {
+    await delay(120);
+    const now = Date.now() / 1000;
+    const step = (days * 86400) / points;
+    const base = source.startsWith('disk.') ? 42 : 60; // temp vs used_pct
+    const amp = source.startsWith('disk.') ? 4 : 15;
+    const out: SeriesPoint[] = [];
+    for (let i = 0; i < points; i++) {
+      const ts = now - (points - i) * step;
+      const wave = Math.sin(i / 9) * amp + Math.sin(i / 3) * amp * 0.2;
+      const val = Math.max(5, Math.min(100, base + wave + ((i * 7) % 5)));
+      out.push({ ts: Math.round(ts), value: Math.round(val * 10) / 10 });
+    }
+    return { source, points: out };
   };
 
   // ---- Datasets ----

--- a/web/src/data/provider.ts
+++ b/web/src/data/provider.ts
@@ -1,7 +1,7 @@
 // Interfaz DataProvider: abstrae el origen de datos (HTTP real o mock demo).
 import type {
   ActivityItem, Alert, BackupFile, BackupStatus, CreateDatasetReq, CreateJobReq, CreatePoolReq, CreateReplicationReq, CreateSnapshotReq, CreateUserReq,
-  Dataset, DatasetProp, DatasetPropsResp, DiffEntry, Disk, DiskSmartLogResp, DiskSmartResp, Job, JobHistoryItem, Lang, LongOp, Overview, Performance, Pool, PoolHistoryEntry, PushAlertTipo, PushPreference, PushQuietHours, PushSubscriptionJSON,
+  Dataset, DatasetProp, DatasetPropsResp, DiffEntry, Disk, DiskSmartLogResp, DiskSmartResp, Job, JobHistoryItem, Lang, LongOp, Overview, Performance, Pool, PoolHistoryEntry, PushAlertTipo, PushPreference, PushQuietHours, PushSubscriptionJSON, SeriesResp,
   Recommendation, ReplicationJob, ReplicationSSHKey, ReplicationTestResult, SessionUser, Settings,
   SnapshotGroup, SystemTimer, SystemTimersResp, UpdateJobReq, UpdateReplicationReq, UpdateStatus, UserInfo, VersionInfo,
 } from './types';
@@ -58,6 +58,7 @@ export interface DataProvider {
   checkpointPool(pool: string, action: 'create' | 'discard', confirm: string): Promise<void>;
   getPoolHistory(pool: string): Promise<PoolHistoryEntry[]>;
   getPerformance(): Promise<Performance>;
+  getSeries(source: string, days: number, points?: number): Promise<SeriesResp>;
   clearPool(pool: string, dev?: string): Promise<void>;
   expandPool(pool: string, vdev: string, disk: string, confirm: string): Promise<void>;
 

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -179,6 +179,16 @@ export interface Performance {
   pools: PoolPerf[];
 }
 
+// GET /api/series?source=&days=&points= (U2: sparklines históricos)
+export interface SeriesPoint {
+  ts: number; // epoch segundos
+  value: number;
+}
+export interface SeriesResp {
+  source: string;
+  points: SeriesPoint[];
+}
+
 export type DatasetType = 'fs' | 'volume';
 export interface Dataset {
   name: string;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -327,6 +327,10 @@ header.top .sub{font-size:13px;color:var(--text2);margin-top:2px}
 .poolhead .grow{flex:1;min-width:150px}
 .poolmeta{display:flex;gap:18px;flex-wrap:wrap;padding:0 16px 14px;font-size:12.5px;color:var(--text2)}
 .poolmeta b{color:var(--text);font-weight:600}
+.sparks{display:flex;gap:12px;align-items:flex-end;margin-top:10px;color:var(--text2)}
+.spark{display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--text2)}
+.spark em{font-style:normal;font-size:11px;color:var(--text3)}
+.spark svg{display:block}
 .vdevs{border-top:1px solid var(--border);padding:10px 16px 14px}
 .vdev{display:flex;align-items:center;gap:9px;font-size:13px;padding:5px 0;color:var(--text2)}
 .vdev .dname{font-family:var(--font-mono);color:var(--text);font-size:12.5px}

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -91,6 +91,8 @@ const es = {
   pool_autotrim_hint: 'TRIM continuo en SSD: libera bloques al borrarse. Alternativa: TRIM programado (tarea trim). En HDD no aplica.',
   pool_history: 'Historial',
   pool_history_hint: 'Comandos ZFS ejecutados sobre este pool (zpool history)',
+  pool_history_series: 'Ocupación del pool los últimos días',
+  pool_history_days: 'Ocupación últimos {days} días',
   hist_title: 'Historial del pool',
   hist_desc: 'Actividad ZFS reciente del pool {pool} (zpool history -i), más reciente primero.',
   hist_date: 'Fecha', hist_cmd: 'Comando', hist_dur: 'Duración',
@@ -353,7 +355,7 @@ const es = {
 
   // Discos
   dk_disk: 'Disco', dk_model: 'Modelo / Serie', dk_size: 'Tamaño',
-  dk_temp: 'Temp.', dk_smart: 'Salud SMART', dk_pool: 'Pool',
+  dk_temp: 'Temp.', dk_temp_hist: 'Temperatura de {dev} (24 h)', dk_smart: 'Salud SMART', dk_pool: 'Pool',
   dk_test_short: 'Test corto', dk_test_long: 'Test largo',
   dk_test_started: 'Test SMART iniciado',
   dk_poweroff: 'Apagar', dk_poweroff_arm: '¿Confirmar?',
@@ -593,6 +595,8 @@ const en: Record<I18nKey, string> = {
   pool_autotrim_hint: 'Continuous TRIM on SSDs: frees blocks as they are deleted. Alternative: scheduled TRIM (trim task). Not applicable to HDDs.',
   pool_history: 'History',
   pool_history_hint: 'ZFS commands run on this pool (zpool history)',
+  pool_history_series: 'Pool capacity over the last days',
+  pool_history_days: 'Capacity over the last {days} days',
   hist_title: 'Pool history',
   hist_desc: 'Recent ZFS activity on pool {pool} (zpool history -i), newest first.',
   hist_date: 'Date', hist_cmd: 'Command', hist_dur: 'Duration',
@@ -847,7 +851,7 @@ const en: Record<I18nKey, string> = {
   wdl_mon: 'Mon', wdl_tue: 'Tue', wdl_wed: 'Wed', wdl_thu: 'Thu', wdl_fri: 'Fri', wdl_sat: 'Sat', wdl_sun: 'Sun',
 
   dk_disk: 'Disk', dk_model: 'Model / Serial', dk_size: 'Size',
-  dk_temp: 'Temp.', dk_smart: 'SMART health', dk_pool: 'Pool',
+  dk_temp: 'Temp.', dk_temp_hist: '{dev} temperature (24 h)', dk_smart: 'SMART health', dk_pool: 'Pool',
   dk_test_short: 'Short test', dk_test_long: 'Long test',
   dk_test_started: 'SMART test started',
   dk_poweroff: 'Power off', dk_poweroff_arm: 'Confirm?',

--- a/web/src/views/Disks.tsx
+++ b/web/src/views/Disks.tsx
@@ -6,8 +6,28 @@ import { useData } from '../ui/useData';
 import { errorMessage, useApp } from '../ui/store';
 import { fmtBytes, fmtInt } from '../ui/format';
 import { Badge, InfoBubble, Spinner } from '../components/ui';
-import type { Disk } from '../data/types';
+import { Sparkline } from '../components/Sparkline';
+import type { Disk, SeriesPoint } from '../data/types';
 import { useModal } from '../components/Modal';
+
+// DiskTempSpark — sparkline de temperatura 24h bajo el valor actual.
+function DiskTempSpark({ dev }: { dev: string }) {
+  const { t } = useApp();
+  const [pts, setPts] = useState<SeriesPoint[] | null>(null);
+  useEffect(() => {
+    let alive = true;
+    getProvider().getSeries(`disk.${dev}.temp`, 1, 80)
+      .then((r) => { if (alive) setPts(r.points); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [dev]);
+  if (!pts || pts.length < 2) return null;
+  return (
+    <div style={{ marginTop: 4, color: 'var(--text3)' }}>
+      <Sparkline points={pts} width={64} height={18} ariaLabel={t('dk_temp_hist', { dev })} />
+    </div>
+  );
+}
 
 const TIPO_SMART: Record<string, 'ok' | 'warn' | 'err' | 'info'> = {
   ok: 'ok', warn: 'warn', crit: 'err', unknown: 'info',
@@ -110,7 +130,10 @@ export default function Disks() {
                   </div>
                 </td>
                 <td className="num hide-md" data-l={t('dk_size')}>{fmtBytes(d.size_bytes)}</td>
-                <td className="num" data-l={t('dk_temp')}>{d.temp_c === null ? '—' : `${d.temp_c}°C`}</td>
+                <td className="num" data-l={t('dk_temp')}>
+                  {d.temp_c === null ? '—' : `${d.temp_c}°C`}
+                  <DiskTempSpark dev={d.dev} />
+                </td>
                 <td className="smartcell">
                   <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
                     <span title={d.smart_detail}>


### PR DESCRIPTION
Adds the first view of historical data to the UI.

**Backend**
- New `GET /api/series?source=&days=&points=` endpoint backed by the
  `series` table, with server-side LTTB downsampling (default 800 points,
  max 2000) so long ranges render as a smooth line without shipping
  thousands of rows.
- Validated params: `source` must be `pool.<name>.used_pct` or
  `disk.<dev>.temp`, `days` 1-365, `points` 50-2000. Empty range returns
  `points: []` (200); no session returns 401.

**Frontend**
- New `Sparkline` SVG component (no dependencies, gradient fill, current
  color).
- Pool cards show capacity over the last 7 and 30 days under the meter.
- Disks view shows a 24h temperature sparkline under each disk's current
  temperature.
- i18n keys in ES and EN; the demo provider returns deterministic
  synthetic series.

Reuses the existing `series` table and its 30-day retention. The full
retention ladder stays out of scope for this iteration.

Closes #25