### PR TITLE
feat(updater): show release notes in update ribbon and backend status

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -22,6 +22,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,14 +34,22 @@ import (
 const (
 	repoSlug     = "gnacho/easyzfs"
 	checksumsFile = "checksums.txt" // fichero único con los hashes de TODOS los assets
+	notesMax     = 600
+)
+
+var (
+	rxHeading = regexp.MustCompile(`(?m)^#{1,4}\s+.*$`)
+	rxBold    = regexp.MustCompile(`\*\*`)
 )
 
 // Status — respuesta de GET /api/update/status.
 type Status struct {
-	Current    string `json:"current"`
-	Latest     string `json:"latest"`
-	Available  bool   `json:"available"`
-	InProgress bool   `json:"inProgress,omitempty"`
+	Current      string `json:"current"`
+	Latest       string `json:"latest"`
+	Available    bool   `json:"available"`
+	InProgress   bool   `json:"inProgress,omitempty"`
+	ReleaseNotes string `json:"releaseNotes,omitempty"`
+	ReleaseURL   string `json:"releaseUrl,omitempty"`
 }
 
 // Updater gestiona el chequeo y la descarga de actualizaciones.
@@ -47,9 +57,11 @@ type Updater struct {
 	current string   // versión local (inyectada por ldflags), sin 'v'
 	dataDir string   // DATA_DIR; el binario nuevo y el flag viven en dataDir/update/
 
-	mu            sync.Mutex
-	currentLatest string // última versión detectada (cache del último Check)
-	inProgress    bool
+	mu               sync.Mutex
+	currentLatest    string // última versión detectada (cache del último Check)
+	currentNotes     string
+	currentURL       string
+	inProgress       bool
 }
 
 // New crea el updater. current es la versión del binario (main.version).
@@ -62,6 +74,23 @@ func stripV(v string) string {
 		return v[1:]
 	}
 	return v
+}
+
+func truncateReleaseNotes(body string) string {
+	if body == "" {
+		return ""
+	}
+	cleaned := rxHeading.ReplaceAllString(body, "")
+	cleaned = rxBold.ReplaceAllString(cleaned, "")
+	cleaned = strings.TrimSpace(cleaned)
+	if len(cleaned) <= notesMax {
+		return cleaned
+	}
+	cut := cleaned[:notesMax]
+	if idx := strings.LastIndexAny(cut, " \n\r\t"); idx > 0 {
+		cut = cut[:idx]
+	}
+	return cut + "…"
 }
 
 // updateDir — directorio escribible por el servicio para el binario nuevo y el flag.
@@ -77,7 +106,7 @@ func (u *Updater) NewBinary() string { return filepath.Join(u.updateDir(), "easy
 func (u *Updater) Status() Status {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	return Status{Current: u.current, Latest: u.currentLatest, InProgress: u.inProgress}
+	return Status{Current: u.current, Latest: u.currentLatest, InProgress: u.inProgress, ReleaseNotes: u.currentNotes, ReleaseURL: u.currentURL}
 }
 
 // Check consulta GitHub y devuelve si hay una release semver más reciente.
@@ -103,6 +132,9 @@ func (u *Updater) Check(ctx context.Context) (Status, error) {
 	}
 
 	latestV := stripV(latest.Version())
+	notes := truncateReleaseNotes(latest.ReleaseNotes)
+	releaseURL := latest.URL
+
 	// Comparación semver defensiva: si la versión local no es semver válido
 	// (p.ej. 'dev' o un build local), se considera al día solo si coincide la
 	// cadena; en caso contrario hay versión nueva.
@@ -119,9 +151,11 @@ func (u *Updater) Check(ctx context.Context) (Status, error) {
 
 	u.mu.Lock()
 	u.currentLatest = latestV
+	u.currentNotes = notes
+	u.currentURL = releaseURL
 	u.mu.Unlock()
 
-	return Status{Current: u.current, Latest: latestV, Available: available}, nil
+	return Status{Current: u.current, Latest: latestV, Available: available, ReleaseNotes: notes, ReleaseURL: releaseURL}, nil
 }
 
 // Apply descarga+valida el binario nuevo a $DATA_DIR/update/easyzfs.new y toca

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -250,16 +250,21 @@ function Shell() {
           )}
           {rel.kind === 'available' && relDismissed !== rel.version && (
             <div className="relbar" role="status">
-              <span>{t('upd_rel_banner', { v: rel.version })}</span>
-              <a href={rel.url} target="_blank" rel="noreferrer">{t('ab_upd_new')}</a>
-              <button className="btn sm primary" style={{ marginLeft: 'auto' }} disabled={applyingRel}
-                onClick={() => { void applyRel(); }}>
-                {applyingRel ? t('ab_updapp') : t('upd_rel_upd')}
-              </button>
-              <button className="btn sm"
-                onClick={() => { dismissRelease(rel.version); setRelDismissed(rel.version); }}>
-                {t('upd_rel_dismiss')}
-              </button>
+              <div className="relbar-body">
+                <span className="relbar-title">{t('upd_rel_banner', { v: rel.version })}</span>
+                {rel.notes && <span className="relbar-notes">{rel.notes}</span>}
+                <div className="relbar-actions">
+                  <a href={rel.url} target="_blank" rel="noreferrer" className="btn sm">{t('ab_upd_new')}</a>
+                  <button className="btn sm primary" disabled={applyingRel}
+                    onClick={() => { void applyRel(); }}>
+                    {applyingRel ? t('ab_updapp') : t('upd_rel_upd')}
+                  </button>
+                  <button className="btn sm"
+                    onClick={() => { dismissRelease(rel.version); setRelDismissed(rel.version); }}>
+                    {t('upd_rel_dismiss')}
+                  </button>
+                </div>
+              </div>
             </div>
           )}
           {demo && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -114,11 +114,23 @@ aside.sidebar.collapsed .sideactions a{justify-content:center;padding:9px 0;flex
   border-radius:12px;font-size:13.5px;font-weight:600;flex-wrap:wrap;
 }
 
-/* ribbon de release nueva en GitHub (releasecheck, check pasivo 1/día) */
+/* ribbon de release nueva en GitHub (releasecheck, check pasivo 1/semana).
+   Layout: título + resumen de novedades + fila de acciones (ver/actualizar/descartar). */
 .relbar{
-  display:flex;align-items:center;gap:10px;margin-bottom:14px;padding:10px 14px;
+  display:flex;align-items:stretch;margin-bottom:14px;padding:12px 14px;
   background:var(--info-soft);color:var(--info);border:1px solid var(--info);
-  border-radius:12px;font-size:13.5px;font-weight:600;flex-wrap:wrap;
+  border-radius:12px;font-size:13.5px;
+}
+.relbar-body{
+  display:flex;flex-direction:column;gap:8px;width:100%;
+}
+.relbar-title{font-weight:700}
+.relbar-notes{
+  font-size:12.5px;font-weight:400;opacity:.85;line-height:1.5;
+  white-space:pre-line;max-height:90px;overflow:hidden;
+}
+.relbar-actions{
+  display:flex;align-items:center;gap:8px;flex-wrap:wrap;
 }
 .relbar a{color:inherit;text-decoration:underline}
 

--- a/web/src/ui/releasecheck.ts
+++ b/web/src/ui/releasecheck.ts
@@ -3,7 +3,8 @@
 // con una GET anónima: el servidor no hace phone-home. Si hay versión más
 // nueva, la shell muestra un ribbon superior (descartable por versión, con
 // botón Actualizar) y Ajustes → Acerca de ofrece "Comprobar actualizaciones"
-// (solo admin; fuerza la consulta al momento).
+// (solo admin; fuerza la consulta al momento). Incluye las release notes
+// (primeros ~600 caracteres del body) para mostrar un resumen de novedades.
 import { useEffect, useState } from 'react';
 
 const REPO = 'gnacho/easyzfs';
@@ -11,13 +12,14 @@ export const RELEASES_URL = `https://github.com/${REPO}/releases`;
 const CACHE_KEY = 'easyzfs-release-check';
 const DISMISS_KEY = 'easyzfs-release-dismissed';
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const NOTES_MAX = 600;
 
 export type ReleaseState =
   | { kind: 'unknown' }
   | { kind: 'uptodate' }
-  | { kind: 'available'; version: string; url: string };
+  | { kind: 'available'; version: string; url: string; notes: string };
 
-interface Cache { ts: number; tag: string; url: string }
+interface Cache { ts: number; tag: string; url: string; notes: string }
 
 // Comparación semver numérica ('v' opcional): 1.10.0 > 1.9.0.
 export function compareSemver(a: string, b: string): number {
@@ -39,14 +41,23 @@ function readCache(): Cache | null {
   } catch { return null; }
 }
 
+function truncateNotes(body: string): string {
+  if (!body) return '';
+  const cleaned = body.replace(/^#{1,4}\s+.*$/gm, '').replace(/\*\*/g, '').trim();
+  if (cleaned.length <= NOTES_MAX) return cleaned;
+  return cleaned.slice(0, NOTES_MAX).replace(/\s+\S*$/, '') + '…';
+}
+
 async function fetchLatest(): Promise<Cache> {
   let res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`);
   let tag = '';
   let url = RELEASES_URL;
+  let notes = '';
   if (res.ok) {
     const j = await res.json();
     tag = j.tag_name ?? '';
     url = j.html_url ?? url;
+    notes = truncateNotes(j.body ?? '');
   } else if (res.status === 404) {
     // Sin release publicada: fallback al último tag
     res = await fetch(`https://api.github.com/repos/${REPO}/tags?per_page=1`);
@@ -57,7 +68,7 @@ async function fetchLatest(): Promise<Cache> {
   } else {
     throw new Error(`HTTP ${res.status}`); // 403 = rate-limit 60/h por IP
   }
-  const c: Cache = { ts: Date.now(), tag, url };
+  const c: Cache = { ts: Date.now(), tag, url, notes };
   try { localStorage.setItem(CACHE_KEY, JSON.stringify(c)); } catch { /* sin storage */ }
   return c;
 }
@@ -65,7 +76,7 @@ async function fetchLatest(): Promise<Cache> {
 function toState(c: Cache | null, currentVersion: string | undefined): ReleaseState {
   if (!c || !c.tag || !currentVersion) return { kind: 'unknown' };
   return compareSemver(c.tag, currentVersion) > 0
-    ? { kind: 'available', version: c.tag.replace(/^v/, ''), url: c.url }
+    ? { kind: 'available', version: c.tag.replace(/^v/, ''), url: c.url, notes: c.notes }
     : { kind: 'uptodate' };
 }
 


### PR DESCRIPTION
## What
When an update is available, the ribbon now shows a summary of the release notes (~600 chars from the GitHub release body) alongside the version number and action buttons. The backend `GET /api/update/status` endpoint also returns `releaseNotes` and `releaseUrl`.

## Changes
- `releasecheck.ts`: extract and cache GitHub release body, truncate to ~600 chars (strip headings/bold)
- `App.tsx`: new ribbon layout with title, notes summary, and action bar
- `index.css`: relbar styles for vertical body + horizontal actions
- `updater.go`: add `ReleaseNotes` and `ReleaseURL` fields to `Status` struct, populated from `go-selfupdate` Release fields

Closes #33