### PR TITLE
fix(smart): handle transient smartctl -t failures with tolerant exit + skip unknown disks

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -361,6 +361,10 @@ Dependencias Go (mantenidas a 2 a propósito):
 
 ## Registro de cambios
 
+### v2.8.6
+
+- **Tests SMART programados más robustos (#35)**: el scheduler ahora maneja fallos transitorios de `smartctl -t` comprobando la salida antes de declarar error (p. ej. exit code 4 = test ya en curso, que es benigno). También se saltan los discos sin soporte SMART en trabajos con target "all" como defensa en profundidad.
+
 ### v2.8.5
 
 - **Resumen de novedades en el aviso de actualización**: cuando hay una versión nueva, el ribbon ahora muestra un resumen de lo que cambió (~600 caracteres del cuerpo de la release de GitHub) junto al número de versión y los botones de acción. La respuesta de `GET /api/update/status` también incluye `releaseNotes` y `releaseUrl`.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ Go dependencies (kept to 2 on purpose):
 
 ## Changelog
 
+### v2.8.6
+
+- **Robust SMART test scheduling (#35)**: the scheduler now handles transient `smartctl -t` failures gracefully by checking the command output before declaring an error (e.g. exit code 4 = test already running, which is benign). Disks without SMART support are also skipped in "all" target jobs as defense in depth.
+
 ### v2.8.5
 
 - **Release notes in the update ribbon**: when a new version is available, the ribbon now shows a summary of what changed (~600 chars from the GitHub release body) alongside the version number and action buttons. The backend `GET /api/update/status` response also includes `releaseNotes` and `releaseUrl`.

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -738,8 +738,14 @@ func (s *Service) SmartTest(ctx context.Context, actor, dev, testType string) er
 		return fmt.Errorf("type inválido (short|long)")
 	}
 	s.audit(ctx, actor, "disk.smart_test."+testType, dev, nil, false)
-	if _, err := executil.Run(ctx, 15*time.Second, "smartctl",
-		"-t", testType, "/dev/"+dev); err != nil {
+	out, err := executil.RunTolerant(ctx, 15*time.Second, "smartctl",
+		"-t", testType, "/dev/"+dev)
+	if err != nil {
+		outStr := string(out)
+		if strings.Contains(outStr, "Testing has begun") ||
+			strings.Contains(outStr, "Self-test has begun") {
+			return nil
+		}
 		return fmt.Errorf("smart test: %w", err)
 	}
 	return nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -320,6 +320,9 @@ func (s *Scheduler) execute(ctx context.Context, j Job) error {
 			}
 			var firstErr error
 			for _, d := range s.disks() {
+				if d.Smart == "unknown" {
+					continue
+				}
 				if err := s.actions.SmartTest(ctx, "scheduler", d.Dev, testType); err != nil && firstErr == nil {
 					firstErr = err
 				}


### PR DESCRIPTION
Closes #35

Two fixes for scheduled SMART test jobs:

1. **`SmartTest()` uses `RunTolerant`** instead of `Run`, so stdout is captured even on non-zero exit. When the output contains "Testing has begun" or "Self-test has begun", the test is considered started regardless of exit code (e.g. exit 4 = test already in progress, which is benign).

2. **Scheduler skips disks without SMART support** when target is "all", as defense in depth (SmartCollector already filters ZVOLs).