### PR TITLE
feat(updater): add weekly auto-update timer

### DIFF
--- a/deploy/easyzfs-update-weekly.service
+++ b/deploy/easyzfs-update-weekly.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=EasyZFS weekly auto-update check and apply
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/easyzfs/easyzfs-update-weekly.sh
+User=root
+StandardOutput=journal
+StandardError=journal

--- a/deploy/easyzfs-update-weekly.sh
+++ b/deploy/easyzfs-update-weekly.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# easyzfs-update-weekly.sh — chequeo y aplicación semanal de actualizaciones.
+#
+# Ejecutado por easyzfs-update-weekly.timer (systemd, cadencia semanal).
+# Descarga la release ESTABLE de GitHub, verifica sha256, hace backup
+# del binario actual, instala el nuevo y reinicia el servicio.
+#
+# A diferencia del apply in-app (POST /api/update/apply → .restart-me flag →
+# easyzfs-update.path → easyzfs-update.service), este script es AUTÓNOMO:
+# no depende de que el servicio esté corriendo ni de un admin que pulse un botón.
+set -eu
+
+APP=easyzfs
+REPO=gnacho/easyzfs
+INSTALL_BIN=/usr/local/bin/easyzfs
+MARKER=/opt/easyzfs/.release-id
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+log() { logger -t "$APP-update-weekly" "$@"; }
+
+# 1. Detectar última release estable
+echo "STEP:detect"
+VER=$(curl -fsSL --max-time 20 "https://api.github.com/repos/$REPO/releases/latest" \
+  | sed -n 's/.*"tag_name": *"\(v\?[0-9][^"]*\)".*/\1/p' | head -n1)
+[ -n "$VER" ] || { log "no se pudo resolver la última release estable"; exit 4; }
+VER_NO_V=$(printf '%s' "$VER" | sed 's/^v//')
+
+# ¿Ya instalado?
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER" 2>/dev/null || true)" = "$VER_NO_V" ]; then
+  log "al día ($VER_NO_V)"; exit 0
+fi
+
+# 2. Descargar binario y checksums
+echo "STEP:download"
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+BIN="${APP}_linux_${ARCH}"
+BASE="https://github.com/$REPO/releases/download/$VER"
+curl -fL --max-time 120 "$BASE/$BIN" -o "$TMP_DIR/$APP"
+curl -fL --max-time 30 "$BASE/checksums.txt" -o "$TMP_DIR/checksums.txt"
+
+# 3. Verificar sha256
+echo "STEP:verify"
+expected=$(awk -v f="$BIN" '$2=="'"$BIN"'" || index($0, "  '"$BIN"'") {print $1; exit}' "$TMP_DIR/checksums.txt" 2>/dev/null || true)
+[ -n "$expected" ] || { log "checksums.txt sin entrada para $BIN (¿release sin checksums?)"; exit 5; }
+got=$(sha256sum "$TMP_DIR/$APP" | awk '{print $1}')
+[ "$expected" = "$got" ] || { log "SHA256 NO coincide para $BIN"; exit 5; }
+log "sha256 verificado: $BIN"
+
+# 4. Backup del binario actual
+echo "STEP:backup"
+if [ -f "$INSTALL_BIN" ]; then
+  cp "$INSTALL_BIN" "${INSTALL_BIN}.bak-$(date +%Y%m%d-%H%M%S)"
+fi
+
+# 5. Instalar y reiniciar
+echo "STEP:install"
+install -m 0755 "$TMP_DIR/$APP" "$INSTALL_BIN"
+printf '%s\n' "$VER_NO_V" > "$MARKER"
+systemctl restart "$APP.service"
+
+log "actualizado a $VER_NO_V"
+echo "OK:$VER_NO_V"

--- a/deploy/easyzfs-update-weekly.timer
+++ b/deploy/easyzfs-update-weekly.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=EasyZFS weekly auto-update timer
+After=network-online.target
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=4h
+
+[Install]
+WantedBy=timers.target

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1062,6 +1062,49 @@ EOF
     run "${SUDO[@]}" systemctl daemon-reload
     run "${SUDO[@]}" systemctl enable --now easyzfs-update.path
     ok "Auto-update: easyzfs-update.path activo (aplica versiones descargadas por /api/update/apply)."
+
+    # Timer de auto-update semanal (patrón Keynest/Deltos): comprueba releases
+    # estables una vez por semana y aplica automáticamente con checksums.
+    local upd_weekly_svc="/etc/systemd/system/easyzfs-update-weekly.service"
+    local upd_weekly_timer="/etc/systemd/system/easyzfs-update-weekly.timer"
+    local upd_script="/opt/easyzfs/easyzfs-update-weekly.sh"
+    if [ "$DRY_RUN" = "1" ]; then
+      info "[DRY-RUN] instalaría easyzfs-update-weekly.timer + .service + script"
+    else
+      "${SUDO[@]}" mkdir -p /opt/easyzfs
+      cp deploy/easyzfs-update-weekly.sh "$upd_script"
+      "${SUDO[@]}" chmod +x "$upd_script"
+      printf '%s\n' "${NEW_VERSION#v}" > /opt/easyzfs/.release-id
+      write_root_file "$upd_weekly_svc" 0644 <<EOF
+[Unit]
+Description=EasyZFS weekly auto-update check and apply
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/easyzfs/easyzfs-update-weekly.sh
+User=root
+StandardOutput=journal
+StandardError=journal
+EOF
+      write_root_file "$upd_weekly_timer" 0644 <<EOF
+[Unit]
+Description=EasyZFS weekly auto-update timer
+After=network-online.target
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=4h
+
+[Install]
+WantedBy=timers.target
+EOF
+      run "${SUDO[@]}" systemctl daemon-reload
+      run "${SUDO[@]}" systemctl enable --now easyzfs-update-weekly.timer
+      ok "Auto-update semanal: easyzfs-update-weekly.timer activo (comprueba y aplica releases estables 1 vez/semana)."
+    fi
   fi
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,6 +237,11 @@ function Shell() {
               </button>
             </div>
           </div>
+          {!collapsed && version && (
+            <div style={{ fontSize: 10, color: 'var(--text3)', padding: '4px 12px 8px', textAlign: 'left' }}>
+              v{version}
+            </div>
+          )}
         </aside>
 
         <main className="main">


### PR DESCRIPTION
## What
EasyZFS now has a weekly auto-update timer (systemd), same pattern as Keynest and Deltos. Every week it checks GitHub for the latest stable release, verifies sha256, backs up the current binary, installs the new one, and restarts.

Previously only the in-app apply button (POST /api/update/apply → .restart-me flag → path unit) could trigger updates. Now the server updates itself automatically once a week.

## Files
- `deploy/easyzfs-update-weekly.sh`: standalone script (detect → download → verify → backup → install → restart)
- `deploy/easyzfs-update-weekly.service`: oneshot root service
- `deploy/easyzfs-update-weekly.timer`: OnCalendar=weekly, Persistent, RandomizedDelaySec=4h
- `deploy/install.sh`: installs timer + script + marker on fresh installs

## Deployed
- citadel-01: timer active, next trigger Mon 2026-08-17 ~02:47 CEST
- citadel-02: timer active, next trigger Mon 2026-08-17 ~01:52 UTC