### PR TITLE
feat(updater): readiness checks, update history, rollback

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -120,6 +120,21 @@ var migrations = []string{
 	  sent_at   TEXT NOT NULL DEFAULT (datetime('now')),
 	  error     TEXT NOT NULL
 	);`,
+	// v18: historial de actualizaciones (#28). Registra cada apply con
+	// versión origen/destino, quién y estado.
+	`CREATE TABLE IF NOT EXISTS update_history (
+	  event_id     TEXT PRIMARY KEY,
+	  timestamp    TEXT NOT NULL DEFAULT (datetime('now')),
+	  action       TEXT NOT NULL DEFAULT 'update',
+	  channel      TEXT NOT NULL DEFAULT 'stable',
+	  version_from TEXT NOT NULL,
+	  version_to   TEXT NOT NULL,
+	  initiated_by TEXT,
+	  status       TEXT NOT NULL DEFAULT 'started',
+	  duration_ms  INTEGER,
+	  notes        TEXT
+	);
+	CREATE INDEX IF NOT EXISTS idx_update_hist_ts ON update_history(timestamp);`,
 }
 
 // Open abre la BD con WAL, busy_timeout y una sola conexión escritora.

--- a/internal/httpapi/update_handlers.go
+++ b/internal/httpapi/update_handlers.go
@@ -1,6 +1,7 @@
 // update_handlers.go — /api/update/*: estado y aplicación de actualizaciones.
 // Patrón app-auto-update: GET /api/update/status (admin, consulta GitHub bajo
-// demanda) y POST /api/update/apply (admin, descarga+valida y toca el flag para
+// demanda), GET /api/update/plan (admin, comprobaciones pre-vuelo) y
+// POST /api/update/apply (admin, descarga+valida y toca el flag para
 // que easyzfs-update.path reinicie con el binario nuevo).
 package httpapi
 
@@ -31,6 +32,15 @@ func (s *Server) getUpdateStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, st)
 }
 
+// getUpdatePlan — GET /api/update/plan (admin). Comprobaciones pre-vuelo.
+func (s *Server) getUpdatePlan(w http.ResponseWriter, r *http.Request) {
+	if s.updater == nil {
+		writeErr(w, http.StatusServiceUnavailable, "update_unavailable", "actualizaciones desactivadas (sin DATA_DIR)")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.updater.Plan())
+}
+
 // postUpdateApply — POST /api/update/apply (admin). Descarga+valida el binario
 // nuevo y toca el flag; el servicio se reinicia vía easyzfs-update.path.
 func (s *Server) postUpdateApply(w http.ResponseWriter, r *http.Request) {
@@ -38,10 +48,29 @@ func (s *Server) postUpdateApply(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusServiceUnavailable, "update_unavailable", "actualizaciones desactivadas (sin DATA_DIR)")
 		return
 	}
+	st := s.updater.Status()
+	eid := s.recordUpdateStart("admin", st.Current, st.Latest)
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Minute)
 	defer cancel()
-	if err := s.updater.Apply(ctx); err != nil {
+	err := s.updater.Apply(ctx)
+	s.recordUpdateResult(eid, err == nil, time.Since(start).Milliseconds())
+	if err != nil {
 		writeErr(w, http.StatusConflict, "update_apply_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "restarting": true})
+}
+
+// postUpdateRollback — POST /api/update/rollback (admin). Restaura el binario
+// anterior (.old) y toca el flag para que easyzfs-update.path reinicie.
+func (s *Server) postUpdateRollback(w http.ResponseWriter, r *http.Request) {
+	if s.updater == nil {
+		writeErr(w, http.StatusServiceUnavailable, "update_unavailable", "actualizaciones desactivadas (sin DATA_DIR)")
+		return
+	}
+	if err := s.updater.Rollback(); err != nil {
+		writeErr(w, http.StatusConflict, "update_rollback_failed", err.Error())
 		return
 	}
 	writeJSON(w, http.StatusAccepted, map[string]any{"ok": true, "restarting": true})
@@ -53,7 +82,10 @@ func (s *Server) wireUpdater(a *http.ServeMux) {
 		return
 	}
 	a.HandleFunc("GET /api/update/status", s.auth.RequireAdmin(s.getUpdateStatus))
+	a.HandleFunc("GET /api/update/plan", s.auth.RequireAdmin(s.getUpdatePlan))
+	a.HandleFunc("GET /api/updates/history", s.auth.RequireAdmin(s.getUpdateHistory))
 	a.HandleFunc("POST /api/update/apply", s.auth.RequireAdmin(s.postUpdateApply))
+	a.HandleFunc("POST /api/update/rollback", s.auth.RequireAdmin(s.postUpdateRollback))
 }
 
 var _ = updater.Status{} // mantener el import si el updater solo se usa vía wiring

--- a/internal/httpapi/update_history.go
+++ b/internal/httpapi/update_history.go
@@ -1,0 +1,75 @@
+// update_history.go — historial de actualizaciones (issue #28).
+// GET /api/updates/history y registro en cada apply.
+package httpapi
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+)
+
+func newEventID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// getUpdateHistory — GET /api/updates/history (admin).
+func (s *Server) getUpdateHistory(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.db.Query(
+		"SELECT event_id, timestamp, action, channel, version_from, version_to, initiated_by, status, duration_ms, notes FROM update_history ORDER BY timestamp DESC LIMIT 30")
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"entries": []any{}})
+		return
+	}
+	defer rows.Close()
+	var entries []map[string]any
+	for rows.Next() {
+		var eid, ts, action, channel, vfrom, vto, status string
+		var initiatedBy, notes *string
+		var durationMs *int64
+		if err := rows.Scan(&eid, &ts, &action, &channel, &vfrom, &vto, &initiatedBy, &status, &durationMs, &notes); err != nil {
+			continue
+		}
+		entry := map[string]any{
+			"event_id": eid, "timestamp": ts, "action": action, "channel": channel,
+			"version_from": vfrom, "version_to": vto, "status": status,
+		}
+		if initiatedBy != nil {
+			entry["initiated_by"] = *initiatedBy
+		}
+		if durationMs != nil {
+			entry["duration_ms"] = *durationMs
+		}
+		if notes != nil {
+			entry["notes"] = *notes
+		}
+		entries = append(entries, entry)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
+}
+
+// recordUpdateStart escribe en update_history antes de aplicar.
+func (s *Server) recordUpdateStart(user string, fromVer, toVer string) string {
+	eid := newEventID()
+	s.db.Exec(
+		"INSERT INTO update_history (event_id, timestamp, action, channel, version_from, version_to, initiated_by, status) VALUES (?, datetime('now'), 'update', 'stable', ?, ?, ?, 'started')",
+		eid, fromVer, toVer, user)
+	return eid
+}
+
+// recordUpdateResult actualiza la entrada tras el apply.
+func (s *Server) recordUpdateResult(eid string, success bool, durationMs int64) {
+	status := "applied"
+	if !success {
+		status = "failed"
+	}
+	msg := ""
+	if !success {
+		msg = fmt.Sprintf("apply failed after %d ms", durationMs)
+	}
+	s.db.Exec(
+		"UPDATE update_history SET status = ?, duration_ms = ?, notes = ? WHERE event_id = ?",
+		status, durationMs, msg, eid)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	selfupdate "github.com/creativeprojects/go-selfupdate"
@@ -287,5 +288,98 @@ func (u *Updater) Apply(ctx context.Context) error {
 		return fmt.Errorf("updater: flag: %w", err)
 	}
 	log.Printf("[easyzfs] actualización %s descargada y validada → %s (flag .restart-me)", stripV(latest.Version()), u.NewBinary())
+	return nil
+}
+
+// ---- readiness checks (#30) ----
+
+// Plan — resultado de la comprobación pre-vuelo antes de aplicar.
+type Plan struct {
+	CanApply bool    `json:"canApply"`
+	Checks   []Check `json:"checks"`
+}
+
+// Check — una comprobación individual con estado y descripción.
+type Check struct {
+	ID      string `json:"id"`
+	Status  string `json:"status"` // "pass" | "warn" | "fail"
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+}
+
+// Plan — comprobaciones pre-vuelo locales (espacio, permisos, concurrencia).
+func (u *Updater) Plan() Plan {
+	u.mu.Lock()
+	inProgress := u.inProgress
+	u.mu.Unlock()
+
+	checks := []Check{
+		{ID: "disk_space", Status: "pass", Title: "Disk space", Summary: "Enough space for download and backup."},
+		{ID: "write_perms", Status: "pass", Title: "Write permissions", Summary: "Data directory is writable."},
+		{ID: "no_concurrent", Status: "pass", Title: "No update in progress", Summary: "No other update is running."},
+	}
+
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(u.dataDir, &st); err == nil {
+		freeMB := st.Bavail * uint64(st.Bsize) / 1024 / 1024
+		if freeMB < 50 {
+			checks[0].Status = "fail"
+			checks[0].Summary = fmt.Sprintf("Only %d MB free in %s (need at least 50 MB).", freeMB, u.dataDir)
+		}
+	}
+
+	if err := os.MkdirAll(u.updateDir(), 0o750); err != nil {
+		checks[1].Status = "fail"
+		checks[1].Summary = fmt.Sprintf("Cannot write to %s: %v", u.updateDir(), err)
+	}
+
+	if inProgress {
+		checks[2].Status = "fail"
+		checks[2].Summary = "An update is already in progress."
+	}
+
+	canApply := true
+	for _, c := range checks {
+		if c.Status == "fail" {
+			canApply = false
+			break
+		}
+	}
+	return Plan{CanApply: canApply, Checks: checks}
+}
+
+// ---- rollback (#29) ----
+
+// Rollback restaura el binario anterior (.old) y toca el flag para que la unit
+// systemd lo instale y reinicie.
+func (u *Updater) Rollback() error {
+	u.mu.Lock()
+	if u.inProgress {
+		u.mu.Unlock()
+		return errors.New("rollback: operation already in progress")
+	}
+	u.inProgress = true
+	u.mu.Unlock()
+	defer func() {
+		u.mu.Lock()
+		u.inProgress = false
+		u.mu.Unlock()
+	}()
+
+	backup := u.NewBinary() + ".old"
+	if _, err := os.Stat(backup); os.IsNotExist(err) {
+		return errors.New("rollback: no backup available (.old not found)")
+	}
+	if err := os.Rename(backup, u.NewBinary()); err != nil {
+		return fmt.Errorf("rollback: rename: %w", err)
+	}
+	if err := os.Chmod(u.NewBinary(), 0o755); err != nil {
+		return fmt.Errorf("rollback: chmod: %w", err)
+	}
+	flag := u.RestartFlag()
+	if err := os.WriteFile(flag, []byte(time.Now().Format(time.RFC3339)), 0o644); err != nil {
+		return fmt.Errorf("rollback: flag: %w", err)
+	}
+	log.Printf("[easyzfs] rollback: restored %s → pending install", backup)
 	return nil
 }

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -60,6 +60,7 @@ export class HttpProvider implements DataProvider {
 
   getVersion = () => get<VersionInfo>('/version');
   getUpdateStatus = () => get<UpdateStatus>('/update/status');
+  getUpdatePlan = () => get<{canApply: boolean; checks: {id:string;status:string;title:string;summary:string}[]}>('/update/plan');
   applyUpdate = async () => { await post<UpdateStatus>('/update/apply'); };
   getSettings = () => get<Settings>('/settings');
   putSettings = (s: Settings) => put<void>('/settings', s);

--- a/web/src/data/mock.ts
+++ b/web/src/data/mock.ts
@@ -242,6 +242,7 @@ export class MockProvider implements DataProvider {
   // ---- Sistema ----
   getVersion = async () => { await delay(); return { ...this.version }; };
   getUpdateStatus = async () => { await delay(); return { current: this.version.version, latest: this.version.version, available: false }; };
+  getUpdatePlan = async () => { await delay(); return { canApply: true, checks: [{id:'disk_space',status:'pass',title:'Disk space',summary:'Enough space available.'}] }; };
   applyUpdate = async () => { await delay(); }; // demo: no-op
   getSettings = async () => { await delay(); return { ...this.settings }; };
   putSettings = async (s: Settings) => { await delay(); this.settings = { ...s }; };

--- a/web/src/data/provider.ts
+++ b/web/src/data/provider.ts
@@ -20,6 +20,7 @@ export interface DataProvider {
 
   // Actualizaciones (admin; el apply reinicia el servicio vía easyzfs-update.path)
   getUpdateStatus(): Promise<UpdateStatus>;
+  getUpdatePlan(): Promise<{canApply: boolean; checks: {id:string;status:string;title:string;summary:string}[]}>;
   applyUpdate(): Promise<void>;
 
   // Copia de seguridad de la BD

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -117,11 +117,16 @@ function UpdateCheckRow({ version }: { version: string | undefined }) {
   const [state, setState] = useState<'idle' | 'checking' | 'uptodate' | 'available' | 'error'>('idle');
   const [applying, setApplying] = useState(false);
   const [latest, setLatest] = useState('');
+  const [checks, setChecks] = useState<{id:string;status:string;title:string;summary:string}[]>([]);
+  const [canApply, setCanApply] = useState(true);
 
   const check = async () => {
     setState('checking');
+    setChecks([]);
     try {
-      const st = await getProvider().getUpdateStatus();
+      const [st, plan] = await Promise.all([getProvider().getUpdateStatus(), getProvider().getUpdatePlan()]);
+      setChecks(plan.checks);
+      setCanApply(plan.canApply);
       if (st.available) {
         setLatest(st.latest);
         setState('available');
@@ -162,8 +167,17 @@ function UpdateCheckRow({ version }: { version: string | undefined }) {
             : t('s_about_d')}
         </div>
       </div>
+      {checks.length > 0 && state === 'available' && (
+        <div className="grow" style={{ flexBasis: '100%', marginTop: 4 }}>
+          {checks.map((c) => (
+            <div key={c.id} className="d" style={{ fontSize: 12, opacity: c.status === 'pass' ? .7 : 1, color: c.status === 'fail' ? 'var(--danger)' : c.status === 'warn' ? 'var(--warn)' : 'inherit' }}>
+              {c.status === 'fail' ? '✗ ' : c.status === 'warn' ? '⚠ ' : '✓ '}{c.summary}
+            </div>
+          ))}
+        </div>
+      )}
       {state === 'available' && (
-        <button className="btn sm primary" disabled={applying} onClick={() => { void apply(); }}>
+        <button className="btn sm primary" disabled={applying || !canApply} onClick={() => { void apply(); }}>
           {applying ? t('ab_updapp') : t('upd_rel_upd')}
         </button>
       )}


### PR DESCRIPTION
## What
Three new features for the EasyZFS updater:

### Readiness checks (#30)
- `GET /api/update/plan` returns pre-flight checks (disk space, write permissions, no concurrent update)
- Settings UI shows check results with pass/warn/fail status before allowing apply

### Update history (#28)
- SQLite migration v18 creates `update_history` table
- `GET /api/updates/history` returns last 30 entries (admin only)
- Every apply records the event with version from/to, status and duration

### Rollback (#29)
- `POST /api/update/rollback` restores the previous binary (.old from go-selfupdate)
- Renames .old → .new → touches .restart-me flag → systemd path unit installs and restarts

Closes #28, closes #29, closes #30