### PR TITLE
Use plain hyphen in browser tab title and PWA manifest name

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,7 +10,7 @@
 <link rel="manifest" href="/manifest.webmanifest">
 <link rel="icon" href="/icons/logo.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/icons/icon-192.png">
-<title>EasyZFS — Gestión ZFS</title>
+<title>EasyZFS - Gestión ZFS</title>
 <script>
 // Apariencia inicial antes del primer paint (evita parpadeo):
 // tema (auto = prefers-color-scheme del SO), acento, densidad y

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "EasyZFS — Gestión ZFS",
+  "name": "EasyZFS - Gestión ZFS",
   "short_name": "EasyZFS",
   "description": "Gestión ZFS ligera para servidores caseros",
   "start_url": "/",


### PR DESCRIPTION
Replace the em dash with a plain hyphen in the browser tab title and PWA manifest name (#53).