### PR TITLE
fix(pwa): allow rotation by setting manifest orientation to any

### DIFF
--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#0e1210",
   "theme_color": "#0e1210",
   "lang": "es",


### PR DESCRIPTION
The web app manifest forced ``portrait``, locking installed PWAs (e.g. an 11" tablet) to portrait even when the device is rotated.

- Set ``orientation`` to ``any`` in ``web/public/manifest.webmanifest``.

Verified in production (citadel-01/02 and demo.easyzfs.cloudless.club): manifest serves ``any``.

closes #56