### PR TITLE
feat(nav): mobile slide transition between views

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -785,3 +785,65 @@ svg{flex-shrink:0}
   *{transition:none!important;animation:none!important}
 }
 html.reduce-motion *{transition:none!important;animation:none!important}
+
+/* Transición móvil entre vistas: el contenido (<main>) se desliza y el shell
+ * (bottom nav) permanece estático. El bottom nav se captura como grupo de
+ * view-transition PROPIO (easyzfs-nav) para no depender de cómo el navegador
+ * capture el grupo root con position:fixed (falla en dispositivos). */
+@media (max-width: 859px) {
+  main.main {
+    view-transition-name: easyzfs-content;
+  }
+  nav.bottomnav {
+    view-transition-name: easyzfs-nav;
+  }
+  /* El shell queda estático: anulamos las 4 animaciones UA de cada grupo
+   * (group/image-pair arrancan en opacity 0 en la hoja UA del navegador). */
+  ::view-transition-group(root),
+  ::view-transition-image-pair(root),
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-group(easyzfs-nav),
+  ::view-transition-image-pair(easyzfs-nav),
+  ::view-transition-old(easyzfs-nav),
+  ::view-transition-new(easyzfs-nav) {
+    animation: none;
+  }
+  html[data-nav-dir='forward']::view-transition-old(easyzfs-content) {
+    animation: easyzfs-vt-out-left 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='forward']::view-transition-new(easyzfs-content) {
+    animation: easyzfs-vt-in-right 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='back']::view-transition-old(easyzfs-content) {
+    animation: easyzfs-vt-out-right 0.3s ease-in-out both;
+  }
+  html[data-nav-dir='back']::view-transition-new(easyzfs-content) {
+    animation: easyzfs-vt-in-left 0.3s ease-in-out both;
+  }
+}
+
+@keyframes easyzfs-vt-out-left {
+  to {
+    transform: translateX(-24%);
+    opacity: 0.7;
+  }
+}
+@keyframes easyzfs-vt-in-right {
+  from {
+    transform: translateX(24%);
+    opacity: 0.7;
+  }
+}
+@keyframes easyzfs-vt-out-right {
+  to {
+    transform: translateX(24%);
+    opacity: 0.7;
+  }
+}
+@keyframes easyzfs-vt-in-left {
+  from {
+    transform: translateX(-24%);
+    opacity: 0.7;
+  }
+}

--- a/web/src/ui/store.tsx
+++ b/web/src/ui/store.tsx
@@ -1,6 +1,7 @@
 // Estado global de la app: sesión, ruta, modo demo, idioma y tema.
 // Router ligero basado en hash (#/vista).
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import type { ReactNode } from 'react';
 import type { Capabilities, SessionUser } from '../data/types';
 import { getProvider, initProvider, enterDemoSession, exitDemoSession } from '../data';
@@ -55,6 +56,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [demo, setDemo] = useState(false);
   const [user, setUser] = useState<SessionUser | null>(null);
   const [route, setRoute] = useState<ViewId>(parseHash());
+  const routeRef = useRef<ViewId>(parseHash());
   const [langMode, setLangModeState] = useState<LangMode>(getLangMode());
   const [themeMode, setThemeModeState] = useState<ThemeMode>(getThemeMode());
   const [themeEff, setThemeEff] = useState<'light' | 'dark'>(effectiveTheme());
@@ -108,8 +110,28 @@ export function AppProvider({ children }: { children: ReactNode }) {
   // Router por hash
   useEffect(() => {
     const onHash = () => {
-      setRoute(parseHash());
-      window.scrollTo({ top: 0 });
+      const next = parseHash();
+      const prev = routeRef.current;
+      routeRef.current = next;
+      if (prev !== next) {
+        try {
+          document.documentElement.dataset.navDir =
+            VIEWS.indexOf(next) > VIEWS.indexOf(prev) ? 'forward' : 'back';
+        } catch {
+          /* sin dataset */
+        }
+        const apply = () => {
+          setRoute(next);
+          window.scrollTo({ top: 0 });
+        };
+        if (typeof document.startViewTransition === 'function') {
+          document.startViewTransition(() => flushSync(apply));
+        } else {
+          apply();
+        }
+      } else {
+        setRoute(next);
+      }
     };
     window.addEventListener('hashchange', onHash);
     return () => window.removeEventListener('hashchange', onHash);


### PR DESCRIPTION
Port of the Helios mobile slide transition to the hash-based navigation flow. Switching views through the bottom navigation on mobile slides the content in the direction of travel (forward/back via html[data-nav-dir]) while the bottom nav stays fixed. Built on the View Transitions API with a fallback to plain navigation where unsupported; respects prefers-reduced-motion and the in-app reduce-motion toggle.

Closes #60