### PR TITLE
feat(replace): stable by-id target, origin/destination summary and healthy-origin warning

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -36,7 +36,18 @@ var (
 	reDataset  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*(/[a-zA-Z0-9][a-zA-Z0-9_.-]*)*$`)
 	reSnapName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$`)
 	reDev      = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,63}$`) // sdb, nvme0n1, ata-XXX…
+	// reDevByIDPath — ruta estable completa '/dev/disk/by-id/<nombre>'.
+	// Es la forma preferida para el disco NUEVO de un replace: las letras
+	// sdX son inestables entre arranques y movimientos de bahía (issue #65).
+	// No se admite '/dev/sdX': solo nombres base o rutas by-id.
+	reDevByIDPath = regexp.MustCompile(`^/dev/disk/by-id/[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$`)
 )
+
+// validNewDev — el destino de un replace/attach puede ser un nombre base
+// ('sda', 'nvme0n1', nombre by-id sin ruta) o una ruta '/dev/disk/by-id/…'.
+func validNewDev(dev string) bool {
+	return reDev.MatchString(dev) || reDevByIDPath.MatchString(dev)
+}
 
 // ValidTopos — topologías admitidas al crear/añadir vdevs.
 var ValidTopos = map[string]bool{
@@ -388,11 +399,14 @@ func (s *Service) SysTaskMigrate(ctx context.Context, actor string, task model.S
 
 // Replace — 'zpool replace <pool> <old> <new>'; el resilver se observa en el colector.
 // confirmed debe ser true solo si el handler validó {"confirm":pool}.
+// newDev debería llegar ya resuelto a la ruta estable '/dev/disk/by-id/…'
+// (lo hace el handler con el inventario de discos); se acepta también un
+// nombre base como fallback cuando el disco no tiene enlace by-id.
 func (s *Service) Replace(ctx context.Context, actor, pool, oldDev, newDev string, confirmed bool) error {
 	if !rePool.MatchString(pool) {
 		return ErrInvalidName
 	}
-	if !reDev.MatchString(oldDev) || !reDev.MatchString(newDev) {
+	if !reDev.MatchString(oldDev) || !validNewDev(newDev) {
 		return ErrInvalidDev
 	}
 	s.audit(ctx, actor, "pool.replace", pool,

--- a/internal/collectors/byid.go
+++ b/internal/collectors/byid.go
@@ -1,0 +1,73 @@
+// byid.go — resolución de discos kernel (sdX, nvme0n1) a su enlace estable
+// /dev/disk/by-id/<nombre>. Las letras sdX son inestables entre arranques y
+// movimientos de bahía; el by-id (modelo+serial o WWN) identifica el disco
+// FÍSICO. Las operaciones destructivas (zpool replace) deben usar by-id
+// siempre que exista (issue #65: replace lanzado contra 'sda', que podía ser
+// otro disco tras un reboot).
+package collectors
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// rePartLink — enlaces de partición creados por udev ('…-part1' → 'sda1'):
+// su destino no es un disco entero, se ignoran.
+var rePartLink = regexp.MustCompile(`-part[0-9]+$`)
+
+// byIDMap escanea dir (normalmente /dev/disk/by-id) y devuelve el mapa
+// nombre-kernel-base ('sda') → mejor nombre by-id ('ata-WDC_WD40…').
+// Los enlaces rotos (disco desaparecido a mitad de escaneo) se saltan.
+// Determinista: os.ReadDir devuelve las entradas ordenadas y el desempate
+// conserva la primera.
+func byIDMap(dir string) map[string]string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	type cand struct {
+		name  string
+		score int
+	}
+	best := map[string]cand{}
+	for _, e := range entries {
+		name := e.Name()
+		if rePartLink.MatchString(name) {
+			continue
+		}
+		target, err := filepath.EvalSymlinks(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		dev := filepath.Base(target)
+		score := byIDScore(name)
+		if prev, ok := best[dev]; !ok || score > prev.score {
+			best[dev] = cand{name: name, score: score}
+		}
+	}
+	out := make(map[string]string, len(best))
+	for dev, c := range best {
+		out[dev] = c.name
+	}
+	return out
+}
+
+// byIDScore — preferencia de estabilidad/legibilidad del enlace by-id:
+// ata-/nvme-/scsi- (llevan modelo+serial) > wwn- > usb- > resto (p.ej.
+// 'nvme-eui.…', lvm, dm-name…). Determinista.
+func byIDScore(name string) int {
+	switch {
+	case strings.HasPrefix(name, "ata-"),
+		strings.HasPrefix(name, "nvme-") && !strings.HasPrefix(name, "nvme-eui."),
+		strings.HasPrefix(name, "scsi-"):
+		return 3
+	case strings.HasPrefix(name, "wwn-"):
+		return 2
+	case strings.HasPrefix(name, "usb-"):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/collectors/byid_test.go
+++ b/internal/collectors/byid_test.go
@@ -1,0 +1,91 @@
+package collectors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkByIDDir crea un sandbox que imita el layout real: root/dev/sdX (ficheros)
+// y root/dev/disk/by-id/<name> → symlinks relativos '../../sdX'. Los destinos
+// EXISTEN para que filepath.EvalSymlinks resuelva (en /dev real los enlaces
+// siempre apuntan a dispositivos existentes). Devuelve el dir by-id.
+func mkByIDDir(t *testing.T, links map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "dev", "disk", "by-id")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, rel := range links {
+		target := filepath.Join(dir, rel)
+		if f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, 0o600); err == nil {
+			f.Close()
+		} else {
+			t.Fatalf("target %s: %v", target, err)
+		}
+		if err := os.Symlink(rel, filepath.Join(dir, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func TestByIDMap(t *testing.T) {
+	dir := mkByIDDir(t, map[string]string{
+		"ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA01":      "../../sdb",
+		"ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA01-part1": "../../sdb1",
+		"wwn-0x5000cca000aaaa01":                     "../../sdb",
+		"wwn-0x5000cca000aaaa01-part1":               "../../sdb1",
+		"nvme-Samsung_SSD_980_1TB_S649NL0R111111":    "../../nvme0n1",
+		"nvme-eui.002538839107fd40":                  "../../nvme0n1",
+		"usb-SanDisk_Ultra_4C530001230919102571-0:0": "../../sda",
+		"dm-name-vg-lv":                              "../../dm-0",
+	})
+	got := byIDMap(dir)
+
+	// disco entero con ata- y wwn-: gana ata- (modelo+serial, score 3 > 2)
+	if got["sdb"] != "ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA01" {
+		t.Errorf("sdb = %q, esperado el enlace ata-", got["sdb"])
+	}
+	// las particiones NO se mapean como discos
+	if _, ok := got["sdb1"]; ok {
+		t.Errorf("sdb1 (partición) no debería aparecer: %q", got["sdb1"])
+	}
+	// nvme- con modelo gana a nvme-eui. (score 3 > 0)
+	if got["nvme0n1"] != "nvme-Samsung_SSD_980_1TB_S649NL0R111111" {
+		t.Errorf("nvme0n1 = %q, esperado el enlace nvme- con modelo", got["nvme0n1"])
+	}
+	// usb- se usa si es lo único que hay
+	if got["sda"] != "usb-SanDisk_Ultra_4C530001230919102571-0:0" {
+		t.Errorf("sda = %q, esperado el enlace usb-", got["sda"])
+	}
+	// destinos que no son discos físicos (dm-0) se mapean igualmente; el
+	// llamador solo consulta discos de lsblk, así que no estorban.
+	if got["dm-0"] != "dm-name-vg-lv" {
+		t.Errorf("dm-0 = %q, esperado dm-name-vg-lv", got["dm-0"])
+	}
+}
+
+func TestByIDMapDirInexistente(t *testing.T) {
+	if got := byIDMap(filepath.Join(t.TempDir(), "no-existe")); got != nil {
+		t.Errorf("dir inexistente: esperado nil, got %v", got)
+	}
+}
+
+func TestByIDScore(t *testing.T) {
+	cases := map[string]int{
+		"ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA01": 3,
+		"nvme-Samsung_SSD_980_1TB_S649NL0R":    3,
+		"scsi-36000c29000000000":               3,
+		"wwn-0x5000cca000aaaa01":               2,
+		"usb-SanDisk_Ultra_XXXX-0:0":           1,
+		"nvme-eui.002538839107fd40":            0,
+		"dm-name-vg-lv":                        0,
+	}
+	for name, want := range cases {
+		if got := byIDScore(name); got != want {
+			t.Errorf("byIDScore(%q)=%d, esperado %d", name, got, want)
+		}
+	}
+}

--- a/internal/collectors/mock.go
+++ b/internal/collectors/mock.go
@@ -187,7 +187,7 @@ func (m *Mock) History(name string) []model.HistoryEntry {
 		}
 	case "ssd":
 		return []model.HistoryEntry{
-			{Ts: now.Add(-40 * time.Minute), Command: "zpool replace ssd 13501483247074580929 nvme1n1", DurationSec: 0.88},
+			{Ts: now.Add(-40 * time.Minute), Command: "zpool replace ssd 13501483247074580929 /dev/disk/by-id/nvme-Samsung_SSD_980_1TB_S649NL0R222222", DurationSec: 0.88},
 			{Ts: now.Add(-2 * time.Hour), Command: "zfs snapshot -r ssd@easyzfs-auto-20260801-0600", DurationSec: 0.91},
 			{Ts: now.Add(-20 * 24 * time.Hour), Command: "zpool set autotrim=on ssd", DurationSec: 0.03},
 			{Ts: now.Add(-60 * 24 * time.Hour), Command: "zpool create ssd mirror nvme0n1 nvme1n1", DurationSec: 1.74},
@@ -440,15 +440,15 @@ func (m *Mock) build() {
 		mkSnap("ssd/vm", "pre-upgrade", 7*24*time.Hour, 20*uint64(gib), "manual"),
 	}
 	m.disks = []model.Disk{
-		{Dev: "sda", Model: "CT500MX500SSD1", Serial: "2034E5A1B2C3", SizeBytes: 500 * uint64(gib), TempC: f64ptr(33), Smart: "ok", SmartDetail: "PASSED", Pool: "", Hours: 18200, SmartFull: mockSmartDetailATA(0)},
+		{Dev: "sda", ByID: "ata-CT500MX500SSD1_2034E5A1B2C3", Model: "CT500MX500SSD1", Serial: "2034E5A1B2C3", SizeBytes: 500 * uint64(gib), TempC: f64ptr(33), Smart: "ok", SmartDetail: "PASSED", Pool: "", Hours: 18200, SmartFull: mockSmartDetailATA(0)},
 		// Disco libre del mismo tamaño que los miembros de tank: candidato a
 		// RAID-Z expansion (lote D) o a sustituir el vdev FAULTED.
-		{Dev: "sde", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA04", SizeBytes: 4 * uint64(tib), TempC: f64ptr(31), Smart: "ok", SmartDetail: "PASSED", Pool: "", Hours: 1200, SmartFull: mockSmartDetailATA(0)},
-		{Dev: "sdb", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA01", SizeBytes: 4 * uint64(tib), TempC: f64ptr(34), Smart: "ok", SmartDetail: "PASSED", Pool: "tank", Hours: 41230, SmartFull: mockSmartDetailATA(0)},
-		{Dev: "sdc", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA02", SizeBytes: 4 * uint64(tib), TempC: f64ptr(35), Smart: "ok", SmartDetail: "PASSED", Pool: "tank", Hours: 41231, SmartFull: mockSmartDetailATA(0)},
-		{Dev: "sdd", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA03", SizeBytes: 4 * uint64(tib), TempC: f64ptr(36), Smart: "warn", SmartDetail: "PASSED (realloc=2 pending=0)", ReallocSectors: 2, Pool: "tank", Hours: 42010, SmartFull: mockSmartDetailATA(2)},
-		{Dev: "nvme0n1", Model: "Samsung SSD 980 1TB", Serial: "S649NL0R111111", SizeBytes: 1 * uint64(tib), TempC: f64ptr(41), Smart: "ok", SmartDetail: "PASSED", Pool: "ssd", Hours: 9800, SmartFull: mockSmartDetailNVMe()},
-		{Dev: "nvme1n1", Model: "Samsung SSD 980 1TB", Serial: "S649NL0R222222", SizeBytes: 1 * uint64(tib), TempC: f64ptr(42), Smart: "ok", SmartDetail: "PASSED", Pool: "ssd", Hours: 9812, SmartFull: mockSmartDetailNVMe()},
+		{Dev: "sde", ByID: "ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA04", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA04", SizeBytes: 4 * uint64(tib), TempC: f64ptr(31), Smart: "ok", SmartDetail: "PASSED", Pool: "", Hours: 1200, SmartFull: mockSmartDetailATA(0)},
+		{Dev: "sdb", ByID: "ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA01", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA01", SizeBytes: 4 * uint64(tib), TempC: f64ptr(34), Smart: "ok", SmartDetail: "PASSED", Pool: "tank", Hours: 41230, SmartFull: mockSmartDetailATA(0)},
+		{Dev: "sdc", ByID: "ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA02", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA02", SizeBytes: 4 * uint64(tib), TempC: f64ptr(35), Smart: "ok", SmartDetail: "PASSED", Pool: "tank", Hours: 41231, SmartFull: mockSmartDetailATA(0)},
+		{Dev: "sdd", ByID: "ata-WDC_WD40EFRX-68N_WD-WCC7K1AAAA03", Model: "WDC WD40EFRX-68N", Serial: "WD-WCC7K1AAAA03", SizeBytes: 4 * uint64(tib), TempC: f64ptr(36), Smart: "warn", SmartDetail: "PASSED (realloc=2 pending=0)", ReallocSectors: 2, Pool: "tank", Hours: 42010, SmartFull: mockSmartDetailATA(2)},
+		{Dev: "nvme0n1", ByID: "nvme-Samsung_SSD_980_1TB_S649NL0R111111", Model: "Samsung SSD 980 1TB", Serial: "S649NL0R111111", SizeBytes: 1 * uint64(tib), TempC: f64ptr(41), Smart: "ok", SmartDetail: "PASSED", Pool: "ssd", Hours: 9800, SmartFull: mockSmartDetailNVMe()},
+		{Dev: "nvme1n1", ByID: "nvme-Samsung_SSD_980_1TB_S649NL0R222222", Model: "Samsung SSD 980 1TB", Serial: "S649NL0R222222", SizeBytes: 1 * uint64(tib), TempC: f64ptr(42), Smart: "ok", SmartDetail: "PASSED", Pool: "ssd", Hours: 9812, SmartFull: mockSmartDetailNVMe()},
 		// Caso real: eMMC de placa (smartctl no la soporta → "unknown", sin
 		// lectura de temperatura → TempC nil, JSON null). En el sistema también
 		// había zd0 y mmcblk0boot0/boot1, pero el filtro de discos físicos los

--- a/internal/collectors/smart.go
+++ b/internal/collectors/smart.go
@@ -220,6 +220,8 @@ func (c *SmartCollector) collectOnce(ctx context.Context) error {
 	}
 	disks := []model.Disk{}
 	crcSeen := map[string]bool{}
+	// Enlaces estables by-id (una pasada por colecta, no por disco).
+	byIDs := byIDMap("/dev/disk/by-id")
 	for _, bd := range inv.BlockDevices {
 		if bd.Type != "disk" || !isPhysicalDisk(bd.Name) {
 			continue
@@ -229,6 +231,7 @@ func (c *SmartCollector) collectOnce(ctx context.Context) error {
 			Model:     strings.TrimSpace(bd.Model),
 			Serial:    bd.Serial,
 			SizeBytes: bd.Size,
+			ByID:      byIDs[bd.Name],
 			// Por defecto "unknown": eMMC / USB sin SAT no hablan smartctl
 			// y no deben aparecer como error ni como "ok".
 			Smart:       "unknown",

--- a/internal/httpapi/pools.go
+++ b/internal/httpapi/pools.go
@@ -132,7 +132,39 @@ func (s *Server) addVdev(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// resolveNewDev — normaliza el disco destino de un replace. Acepta nombre
+// base ('sda'), '/dev/sda' o ruta by-id ('/dev/disk/by-id/ata-…') y lo
+// resuelve contra el inventario de discos: devuelve la forma canónica
+// preferida para zpool ('/dev/disk/by-id/<id>' si el disco tiene enlace,
+// si no el nombre base) y el nombre base (para las guardas). Si el disco
+// no está en el inventario, devuelve la entrada saneada y ok=false (la
+// guarda de tamaño no podrá aplicarse, como ocurría antes) — issue #65.
+func (s *Server) resolveNewDev(in string) (canonical, base string, ok bool) {
+	in = strings.TrimSpace(in)
+	if strings.HasPrefix(in, "/dev/disk/by-id/") {
+		id := strings.TrimPrefix(in, "/dev/disk/by-id/")
+		for _, d := range s.disks.Disks() {
+			if d.ByID != "" && d.ByID == id {
+				return "/dev/disk/by-id/" + d.ByID, d.Dev, true
+			}
+		}
+		return in, id, false
+	}
+	base = stripPart(strings.TrimPrefix(in, "/dev/"))
+	for _, d := range s.disks.Disks() {
+		if d.Dev == base {
+			if d.ByID != "" {
+				return "/dev/disk/by-id/" + d.ByID, base, true
+			}
+			return base, base, true
+		}
+	}
+	return base, base, false
+}
+
 // replaceDisk — POST /api/pools/{name}/replace {old_dev, new_dev, confirm} → 202.
+// new_dev admite nombre base, '/dev/sdX' o ruta by-id; se resuelve SIEMPRE a
+// '/dev/disk/by-id/…' cuando el disco tiene enlace estable (issue #65).
 func (s *Server) replaceDisk(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	var body struct {
@@ -146,13 +178,14 @@ func (s *Server) replaceDisk(w http.ResponseWriter, r *http.Request) {
 	if !requireConfirm(w, body.Confirm, name) {
 		return
 	}
-	if body.OldDev == body.NewDev {
+	newCanonical, newBase, _ := s.resolveNewDev(body.NewDev)
+	oldBase := stripPart(strings.TrimPrefix(body.OldDev, "/dev/"))
+	if body.OldDev == body.NewDev || oldBase == newBase {
 		writeErr(w, http.StatusConflict, "same_dev", "el disco nuevo no puede ser el mismo que el sustituido")
 		return
 	}
 	// Guarda: el disco nuevo no puede ser miembro de ningún pool (evita el
 	// error críptico de zpool 'is part of active pool').
-	newBase := stripPart(strings.TrimPrefix(body.NewDev, "/dev/"))
 	for _, p := range s.pools.Pools() {
 		for _, v := range p.Vdevs {
 			key := stripPart(strings.TrimPrefix(v.Path, "/dev/"))
@@ -176,7 +209,7 @@ func (s *Server) replaceDisk(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	if err := s.act.Replace(r.Context(), actor(r), name, body.OldDev, body.NewDev, true); err != nil {
+	if err := s.act.Replace(r.Context(), actor(r), name, body.OldDev, newCanonical, true); err != nil {
 		actionErr(w, err)
 		return
 	}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -132,6 +132,11 @@ type Disk struct {
 	Model     string `json:"model"`
 	Serial    string `json:"serial"`
 	SizeBytes uint64 `json:"size_bytes"`
+	// ByID — nombre del enlace estable /dev/disk/by-id/<ByID> (modelo+serial
+	// o WWN). Vacío si el disco no tiene enlace by-id (p.ej. algunas eMMC).
+	// Las operaciones destructivas (replace) deben usarlo en vez de Dev:
+	// las letras sdX son inestables entre arranques (issue #65).
+	ByID string `json:"by_id,omitempty"`
 	// TempC es nil (JSON null) cuando no hay lectura (eMMC, USB sin SAT,
 	// smartctl no disponible): "sin dato" no es lo mismo que 0 °C.
 	TempC       *float64 `json:"temp_c"`

--- a/web/src/components/Modals.tsx
+++ b/web/src/components/Modals.tsx
@@ -1092,7 +1092,9 @@ function PoolDiskModal({ pool, mode, presetOld, presetNew, onClose }: { pool: st
   const [showAll, setShowAll] = useState(false);
   // tamaño del vdev a sustituir (si el disco viejo sigue visible): el nuevo debe ser >=
   const oldVdev = current.find((v) => v.dev === oldDev);
-  const oldSize = (disks ?? []).find((d) => oldVdev?.path && d.dev === devBase(oldVdev.path))?.size_bytes ?? 0;
+  const oldDisk = (disks ?? []).find((d) => oldVdev?.path ? d.dev === devBase(oldVdev.path) : d.dev === oldDev);
+  const newDisk = (disks ?? []).find((d) => d.dev === newDev);
+  const oldSize = oldDisk?.size_bytes ?? 0;
   const suitable = useMemo(() => free.filter((d) => oldSize === 0 || d.size_bytes >= oldSize), [free, oldSize]);
   const hidden = free.length - suitable.length;
   const toggle = (dev: string) => setSel((s) => {
@@ -1122,7 +1124,11 @@ function PoolDiskModal({ pool, mode, presetOld, presetNew, onClose }: { pool: st
     setBusy(true); setErr('');
     try {
       if (mode === 'vdev') await getProvider().addVdev(pool, topo, [...sel], confirm.trim());
-      else await getProvider().replaceDisk(pool, oldDev, newDev, confirm.trim());
+      else {
+        // by-id si existe: las letras sdX son inestables entre arranques (#65)
+        const outDev = newDisk?.by_id ? '/dev/disk/by-id/' + newDisk.by_id : newDev;
+        await getProvider().replaceDisk(pool, oldDev, outDev, confirm.trim());
+      }
       refresh(); onClose();
     } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
   };
@@ -1196,8 +1202,36 @@ function PoolDiskModal({ pool, mode, presetOld, presetNew, onClose }: { pool: st
                   {t('rp_show_all', { n: hidden })}
                 </label>
               )}
-            </>);
+             </>);
           })()}
+
+          {/* #65: resumen explícito origen/destino con modelo+serial antes de confirmar */}
+          <div className="rp-summary">
+            <div>
+              <span className="lbl">{t('rp_old')}</span>
+              <span className="mono">
+                {oldVdev?.path ? oldVdev.path.replace('/dev/', '') : oldDev}
+                {oldDisk ? ` · ${oldDisk.model} · S/N ${oldDisk.serial}` : ''}
+              </span>
+            </div>
+            <div>
+              <span className="lbl">{t('rp_new')}</span>
+              <span className="mono">
+                {newDev}
+                {newDisk ? ` · ${newDisk.model} · S/N ${newDisk.serial}` : ''}
+              </span>
+            </div>
+            {newDisk?.by_id && (
+              <div>
+                <span className="lbl">{t('rp_byid')}</span>
+                <span className="mono wrap">/dev/disk/by-id/{newDisk.by_id}</span>
+              </div>
+            )}
+          </div>
+          {/* #65: aviso fuerte si el origen es un miembro ONLINE sano */}
+          {oldVdev?.status === 'ONLINE' && (
+            <p className="rp-warn" role="alert">{t('rp_warn_online')}</p>
+          )}
         </>)}
 
         <label htmlFor="pd-confirm">{t('ex_confirm_lbl_pool')}</label>

--- a/web/src/data/mock.ts
+++ b/web/src/data/mock.ts
@@ -141,12 +141,12 @@ export class MockProvider implements DataProvider {
   // temperatura, un NVMe Samsung de sistema y tres ORICO de datos.
   private disks: Disk[] = [
     { dev: 'mmcblk0', model: 'eMMC 5.1 (64 GB)', serial: '—', size_bytes: Math.round(58.2 * GiB), temp_c: null, smart: 'unknown', smart_detail: '', pool: '—', hours: 0 },
-    { dev: 'nvme3n1', model: 'Samsung MZVLB256HAHQ', serial: 'S417NB0K402133', size_bytes: Math.round(238 * GiB), temp_c: 55, smart: 'ok', smart_detail: 'PASSED', pool: 'ssd', hours: 1577 },
-    { dev: 'nvme0n1', model: 'ORICO NVMe SSD', serial: 'ORC2024A01', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: 'tank', hours: 8725 },
-    { dev: 'nvme1n1', model: 'ORICO NVMe SSD', serial: 'ORC2024A02', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: 'tank', hours: 8725 },
-    { dev: 'nvme2n1', model: 'ORICO NVMe SSD', serial: 'ORC2024A03', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: '—', hours: 8725 },
+    { dev: 'nvme3n1', by_id: 'nvme-Samsung_MZVLB256HAHQ_S417NB0K402133', model: 'Samsung MZVLB256HAHQ', serial: 'S417NB0K402133', size_bytes: Math.round(238 * GiB), temp_c: 55, smart: 'ok', smart_detail: 'PASSED', pool: 'ssd', hours: 1577 },
+    { dev: 'nvme0n1', by_id: 'nvme-ORICO_NVMe_SSD_ORC2024A01', model: 'ORICO NVMe SSD', serial: 'ORC2024A01', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: 'tank', hours: 8725 },
+    { dev: 'nvme1n1', by_id: 'nvme-ORICO_NVMe_SSD_ORC2024A02', model: 'ORICO NVMe SSD', serial: 'ORC2024A02', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: 'tank', hours: 8725 },
+    { dev: 'nvme2n1', by_id: 'nvme-ORICO_NVMe_SSD_ORC2024A03', model: 'ORICO NVMe SSD', serial: 'ORC2024A03', size_bytes: Math.round(1.86 * TiB), temp_c: 48, smart: 'ok', smart_detail: 'PASSED', pool: '—', hours: 8725 },
     // Caso real: disco USB montado (en uso) — no debe ofrecerse como libre.
-    { dev: 'sda', model: 'Seagate Expansion 4TB', serial: 'NAABC123', size_bytes: Math.round(3.64 * TiB), temp_c: 38, smart: 'warn', smart_detail: 'PASSED (realloc=48 pending=0)', realloc_sectors: 48, pool: '—', in_use: true, hours: 22100 },
+    { dev: 'sda', by_id: 'usb-Seagate_Expansion_4TB_NAABC123-0:0', model: 'Seagate Expansion 4TB', serial: 'NAABC123', size_bytes: Math.round(3.64 * TiB), temp_c: 38, smart: 'warn', smart_detail: 'PASSED (realloc=48 pending=0)', realloc_sectors: 48, pool: '—', in_use: true, hours: 22100 },
   ];
 
   private systemTimers: SystemTimer[] = [

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -308,6 +308,7 @@ export interface Disk {
   model: string;
   serial: string;
   size_bytes: number;
+  by_id?: string; // enlace estable /dev/disk/by-id/<by_id> (issue #65); vacío si no existe
   temp_c: number | null; // null = sensor no disponible (p. ej. eMMC)
   smart: 'ok' | 'warn' | 'crit' | 'unknown'; // unknown = SMART no disponible
   smart_detail: string;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -603,6 +603,12 @@ table.data td.num{font-family:var(--font-mono);font-size:12.5px}
 .diskpick{display:flex;align-items:center;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:10px;margin-top:8px;cursor:pointer}
 .diskpick.sel{border-color:var(--accent);background:var(--accent-soft)}
 .form-err{color:var(--err);font-size:12.5px;margin-top:10px;font-weight:600}
+/* #65: resumen origen/destino del replace y aviso de origen sano */
+.rp-summary{display:flex;flex-direction:column;gap:7px;margin-top:12px;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--surface2);font-size:12.5px}
+.rp-summary>div{display:flex;gap:10px;align-items:baseline;min-width:0}
+.rp-summary .lbl{color:var(--text2);font-weight:700;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;white-space:nowrap}
+.rp-summary .mono.wrap{word-break:break-all}
+.rp-warn{margin-top:10px;padding:10px 12px;border:1px solid var(--warn);border-left-width:3px;border-radius:10px;background:var(--warn-soft);color:var(--text);font-size:12.5px;font-weight:600}
 
 /* alertas */
 .alert{display:flex;gap:12px;padding:13px 16px;border-bottom:1px solid var(--border);font-size:13.5px}

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -160,6 +160,8 @@ const es = {
   rp_btn: 'Sustituir disco',
   rp_small: 'pequeño', rp_small_hidden: '({n} oculto(s) por tamaño)',
   rp_show_all: 'Mostrar también los {n} disco(s) de tamaño insuficiente',
+  rp_byid: 'Ruta estable',
+  rp_warn_online: 'El disco de origen está ONLINE y sano. Sustituir un disco sano dispara un resilver innecesario: comprueba que es exactamente lo que quieres hacer.',
 
   // Retirar disco de un mirror
   dt_title: 'Retirar disco',
@@ -663,6 +665,8 @@ const en: Record<I18nKey, string> = {
   rp_btn: 'Replace disk',
   rp_small: 'too small', rp_small_hidden: '({n} hidden by size)',
   rp_show_all: 'Also show the {n} undersized disk(s)',
+  rp_byid: 'Stable path',
+  rp_warn_online: 'The origin disk is ONLINE and healthy. Replacing a healthy disk triggers an unnecessary resilver: double-check this is exactly what you want to do.',
 
   dt_title: 'Detach disk',
   dt_desc: '{dev} will be permanently detached from pool {pool}. Data stays safe on the rest of the mirror.',


### PR DESCRIPTION
Closes #65

Disk replacement now resolves the target to its stable `/dev/disk/by-id` path whenever one exists (kernel sdX names are unstable across boots and bay moves). The inventory carries each disk's best by-id link (ata-/nvme-/scsi- with model+serial preferred over wwn- and usb-; partition links excluded), and the replace handler canonicalises base names, /dev/sdX or by-id paths to the stable form, with all guards (same disk, in use, size) comparing the resolved base name.

The replace modal shows an explicit origin/destination summary (both disks with model and serial, plus the stable path that will be used) and a strong warning when the selected origin vdev is ONLINE and healthy.

Verified: Go suite and staticcheck clean; Playwright 17/17 against a mock instance (summary rows, warning toggling with origin status, request payload using the by-id path); API guards return 409 for same-disk and in-use targets submitted in mixed base/by-id forms.