### PR TITLE
feat(i18n): default the demo deployment UI to English

### DIFF
--- a/internal/httpapi/system.go
+++ b/internal/httpapi/system.go
@@ -64,13 +64,18 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 
 // publicDemo — GET /api/public/demo (sin auth): el login lo consulta para
 // mostrar u ocultar el botón "Entrar como demo" según el ajuste del admin.
+// demo_server indica que ESTE servidor es el despliegue demo (DEMO=1); el
+// frontend lo usa para resolver el idioma por defecto (auto → inglés).
 func (s *Server) publicDemo(w http.ResponseWriter, r *http.Request) {
 	st, err := s.settings.Load(r.Context())
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "db_error", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]bool{"demo_enabled": st.DemoEnabled})
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"demo_enabled": st.DemoEnabled,
+		"demo_server":  s.cfg.Demo,
+	})
 }
 
 // putSettings — PUT /api/settings (admin) → 204. 400 si los rangos no valen.

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -11,18 +11,31 @@ import type {
 
 const BASE = '/api';
 
-// Modo demo habilitado (GET /api/public/demo, sin sesión): lo consulta el
-// login para mostrar u ocultar el botón "Entrar como demo". Fuera del
-// provider porque se llama ANTES de autenticarse.
-export async function fetchDemoEnabled(): Promise<boolean> {
-  try {
-    const res = await fetch(`${BASE}/public/demo`, { credentials: 'same-origin' });
-    if (!res.ok) return true; // sin respuesta: por defecto se ofrece (como antes)
-    const j = await res.json();
-    return j?.demo_enabled !== false;
-  } catch {
-    return true; // sin red: se ofrece el botón igualmente
+// Estado público del demo (GET /api/public/demo, sin sesión): lo consulta el
+// login para mostrar u ocultar el botón "Entrar como demo" y main.tsx para
+// resolver el idioma por defecto. Fuera del provider porque se llama ANTES de
+// autenticarse. Single-flight: main.tsx y Login comparten la misma petición.
+export interface PublicDemo {
+  enabled: boolean; // ajuste del admin: se ofrece el botón de demo
+  server: boolean;  // este servidor ES el despliegue demo (DEMO=1)
+}
+
+let publicDemoPromise: Promise<PublicDemo> | null = null;
+
+export function fetchPublicDemo(): Promise<PublicDemo> {
+  if (!publicDemoPromise) {
+    publicDemoPromise = (async () => {
+      try {
+        const res = await fetch(`${BASE}/public/demo`, { credentials: 'same-origin' });
+        if (!res.ok) return { enabled: true, server: false }; // sin respuesta: botón visible, servidor no-demo
+        const j = await res.json();
+        return { enabled: j?.demo_enabled !== false, server: j?.demo_server === true };
+      } catch {
+        return { enabled: true, server: false }; // sin red: botón visible, servidor no-demo
+      }
+    })();
   }
+  return publicDemoPromise;
 }
 
 async function req<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,8 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { hasDemoSession } from './data';
+import { fetchPublicDemo } from './data/http';
+import { setDemoServer } from './ui/i18n';
 // Fuentes self-hosted (offline/LAN): Space Grotesk = voz UI, JetBrains Mono = datos
 import '@fontsource/space-grotesk/400.css';
 import '@fontsource/space-grotesk/500.css';
@@ -13,14 +15,23 @@ import '@fontsource/jetbrains-mono/500.css';
 import '@fontsource/jetbrains-mono/600.css';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// En el despliegue demo (DEMO=1) el idioma automático se resuelve a inglés
+// ANTES del primer render para evitar un destello del idioma del navegador.
+// Timeout corto: si el flag no llega a tiempo se renderiza igualmente.
+function render(): void {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
 
-// Service worker (Web Push): solo si el navegador lo soporta y la sesión NO
-// es demo (en demo no hay push real; ver skill web-push-alerts).
-if ('serviceWorker' in navigator && !hasDemoSession()) {
-  navigator.serviceWorker.register('/sw.js').catch(() => { /* push no disponible */ });
+  // Service worker (Web Push): solo si el navegador lo soporta y la sesión NO
+  // es demo (en demo no hay push real; ver skill web-push-alerts).
+  if ('serviceWorker' in navigator && !hasDemoSession()) {
+    navigator.serviceWorker.register('/sw.js').catch(() => { /* push no disponible */ });
+  }
 }
+
+const flag = fetchPublicDemo().then((d) => { if (d.server) setDemoServer(true); });
+const timeout = new Promise<void>((resolve) => { setTimeout(resolve, 400); });
+Promise.race([flag, timeout]).finally(render);

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -1015,9 +1015,23 @@ const LANG_KEY_LEGACY = 'zfc-lang';
 
 let currentLang: 'es' | 'en' = 'es';
 const subs = new Set<() => void>();
+// true solo en el despliegue demo (DEMO=1, flag público del backend): el modo
+// auto se resuelve a inglés, la elección explícita del usuario sigue mandando.
+let demoServer = false;
+
+export function setDemoServer(v: boolean): void {
+  if (demoServer === v) return;
+  demoServer = v;
+  if (getLangMode() === 'auto') {
+    currentLang = resolveLang('auto');
+    document.documentElement.lang = currentLang;
+    subs.forEach((f) => f());
+  }
+}
 
 export function resolveLang(mode: LangMode): 'es' | 'en' {
   if (mode === 'auto') {
+    if (demoServer) return 'en';
     return (navigator.language || 'es').toLowerCase().startsWith('en') ? 'en' : 'es';
   }
   return mode;

--- a/web/src/views/Login.tsx
+++ b/web/src/views/Login.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useState } from 'react';
 import { useApp } from '../ui/store';
 import { ApiError } from '../data/types';
-import { fetchDemoEnabled } from '../data/http';
+import { fetchPublicDemo } from '../data/http';
 import { Logo } from '../components/icons';
 
 export default function Login() {
@@ -22,7 +22,7 @@ export default function Login() {
 
   useEffect(() => {
     let alive = true;
-    void fetchDemoEnabled().then((ok) => { if (alive) setDemoOk(ok); });
+    void fetchPublicDemo().then((d) => { if (alive) setDemoOk(d.enabled); });
     return () => { alive = false; };
   }, []);
 


### PR DESCRIPTION
Expose a demo_server flag on GET /api/public/demo (DEMO=1) and resolve the auto language to English on that deployment before first render. Explicit language choices and regular instances keep their behaviour, so visitors with Spanish browsers see the public demo in English while real installs are untouched.

Closes #73