### PR TITLE
feat(web): add languages icon next to language selector in settings

### DIFF
--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -46,6 +46,7 @@ export const IconPencil = (p: P) => base(p, <><path d="M17 3a2.85 2.83 0 1 1 4 4
 export const IconMail = (p: P) => base(p, <><rect width="20" height="16" x="2" y="4" rx="2" /><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" /></>);
 // Icono de refresco (patrón lucide RefreshCw): pull-to-refresh móvil
 export const IconRefresh = (p: P) => base(p, <><path d="M21 12a9 9 0 1 1-9-9" /><path d="M21 3v6h-6" /></>);
+export const IconLanguages = (p: P) => base(p, <><path d="m5 8 6 6" /><path d="m4 14 6-6 2-3" /><path d="M2 5h12" /><path d="M7 2h1" /><path d="m22 22-5-10-5 10" /><path d="M14 18h6" /></>);
 // Logo de la app: diseño "E de capas" (assets de branding en /icons)
 export function Logo({ size = 30 }: { size?: number }) {
   return (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -243,9 +243,11 @@ aside.sidebar.collapsed .sideactions a{justify-content:center;padding:9px 0;flex
   color:var(--text);font:inherit;font-size:13px;padding:0 8px;cursor:pointer;
 }
 .plang:focus{outline:2px solid var(--accent);outline-offset:-1px}
-/* Idioma en móvil: solo icono; desktop: select completo */
+/* Idioma en móvil: solo icono; desktop: icono + select completo */
 .lang-mobile{display:none}
-.lang-desktop{width:120px}
+.lang-desktop{display:inline-flex;align-items:center;gap:7px;color:var(--text2)}
+.lang-desktop svg{flex-shrink:0}
+.lang-desktop .plang{width:120px}
 @media(max-width:639px){.lang-mobile{display:inline-flex}.lang-desktop{display:none}}
 .plogout{
   margin-left:auto;border-color:color-mix(in srgb, var(--err) 35%, transparent);

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -11,7 +11,7 @@ import { getProvider } from '../data';
 import { errorMessage, useApp } from '../ui/store';
 import { fmtBytes, timeAgo } from '../ui/format';
 import { Seg, Select, Spinner, Switch, Badge } from '../components/ui';
-import { Logo, IconCode, IconList, IconHeart, IconShield, IconCheck, IconUpload, IconCamera, IconChev, IconData, IconUser, IconX, IconTrash, IconLock, IconBell, IconMail, IconPencil, IconLogout, IconSun, IconMoon, IconMonitor } from '../components/icons';
+import { Logo, IconCode, IconList, IconHeart, IconShield, IconCheck, IconUpload, IconCamera, IconChev, IconData, IconUser, IconX, IconTrash, IconLock, IconBell, IconMail, IconPencil, IconLogout, IconSun, IconMoon, IconMonitor, IconLanguages } from '../components/icons';
 import { useModal } from '../components/Modal';
 import { AvatarCropDialog } from '../components/AvatarCropDialog';
 import { usePush } from '../data/push';
@@ -590,14 +590,17 @@ function ProfileCard() {
     <>
       <label className="pact-ico lang-mobile" aria-label={t('s_lang')} title={t('s_lang')}
         onClick={(e) => { e.preventDefault(); const s = document.getElementById('mp-lang'); if (s) { (s as HTMLSelectElement).focus(); (s as HTMLSelectElement).click(); } }}>
-        <IconMonitor size={16} />
+        <IconLanguages size={16} />
       </label>
-      <select id="mp-lang" className="plang lang-desktop" value={langMode} onChange={(e) => setLang(e.target.value as Lang)}
-        aria-label={t('s_lang')} title={t('s_lang')}>
-        <option value="auto">{t('s_lang_auto')}</option>
-        <option value="es">Español</option>
-        <option value="en">English</option>
-      </select>
+      <span className="lang-desktop">
+        <IconLanguages size={16} aria-hidden="true" />
+        <select id="mp-lang" className="plang" value={langMode} onChange={(e) => setLang(e.target.value as Lang)}
+          aria-label={t('s_lang')} title={t('s_lang')}>
+          <option value="auto">{t('s_lang_auto')}</option>
+          <option value="es">Español</option>
+          <option value="en">English</option>
+        </select>
+      </span>
     </>
   );
 


### PR DESCRIPTION
Add IconLanguages (lucide languages icon, hand-rolled SVG like the rest of the icon set) next to the language selector in Settings: it replaces the generic monitor icon on the mobile trigger and appears beside the select on desktop.

Closes #76