### PR TITLE
fix(landing): restore goatcounter tracker lost in previous deploy

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -84,6 +84,7 @@
     ]
   }
   </script>
+<script data-goatcounter="https://stats.easyzfs.cloudless.club/count" async src="//stats.easyzfs.cloudless.club/count.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main" data-i18n="misc.skip">Saltar al contenido</a>


### PR DESCRIPTION
The GoatCounter tracker was added on 16-Aug only in the unmerged `fix/landing-motion` branch and deployed by hand; the 20-Aug index.html replacement (#70) was based on `main` and silently removed it. Since then easyzfs.cloudless.club recorded zero visits (GoatCounter site 3 had only 3 hits: creation test + 16-Aug verification).

Restores the tracker line (same pattern as the keynest/helios/goatdash/ghostbird/cloudless.landings).

Verified end-to-end in production:
- `index.html` md5 prod == repo
- Playwright with real UA: `count.js` loads and `POST /count` is sent, zero JS errors
- GoatCounter DB shows the new hit for 20-Aug (site 3)

Closes #82