### PR TITLE
feat(series): long-term capacity trends with daily rollup and trends view

### DIFF
--- a/internal/collectors/mantenimiento.go
+++ b/internal/collectors/mantenimiento.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	alertsRetentionDays  = 90
-	historyRetentionDays = 180
+	alertsRetentionDays      = 90
+	historyRetentionDays     = 180
+	seriesDailyRetentionDays = 1825 // 5 años de tendencia diaria (#85)
 )
 
 // Mantenimiento — colector diario de limpieza (lección 4: toda serie tiene retención).
@@ -59,10 +60,21 @@ func (m *Mantenimiento) maybeRun(ctx context.Context) {
 
 // purge — la limpieza propiamente dicha. Fallos: log y seguir (no críticos).
 func (m *Mantenimiento) purge(ctx context.Context) {
+	// 1. Agregar crudas viejas a series_daily ANTES de purgarlas (tendencia larga).
+	if n, err := db.RollupSeriesToDaily(ctx, m.db, m.retentionDays); err != nil {
+		log.Printf("mantenimiento: rollup series→daily: %v", err)
+	} else if n > 0 {
+		log.Printf("mantenimiento: %d puntos de serie agregados a diario", n)
+	}
 	if n, err := db.PurgeSeries(ctx, m.db, m.retentionDays); err != nil {
 		log.Printf("mantenimiento: purga series: %v", err)
 	} else if n > 0 {
 		log.Printf("mantenimiento: %d puntos de serie purgados", n)
+	}
+	if n, err := db.PurgeSeriesDaily(ctx, m.db, seriesDailyRetentionDays); err != nil {
+		log.Printf("mantenimiento: purga series_daily: %v", err)
+	} else if n > 0 {
+		log.Printf("mantenimiento: %d días de serie diaria purgados", n)
 	}
 	if err := db.PurgeSessions(ctx, m.db); err != nil {
 		log.Printf("mantenimiento: purga sesiones: %v", err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"strconv"
 
 	_ "modernc.org/sqlite"
 )
@@ -148,6 +149,20 @@ var migrations = []string{
 	  created_at TEXT NOT NULL DEFAULT (datetime('now')),
 	  PRIMARY KEY (user, code_hash)
 	);`,
+	// v20: tendencia de capacidad larga (#85). series_daily agrega por día
+	// (AVG/MIN/MAX) las muestras crudas que van a purgarse, permitiendo rangos
+	// de hasta 5 años sin guardar todo el detalle. El mantenimiento rellena
+	// esta tabla ANTES de borrar las crudas; Range() la usa para from < hoy-30d.
+	`CREATE TABLE IF NOT EXISTS series_daily (
+	  source TEXT NOT NULL,
+	  day    TEXT NOT NULL,
+	  avg    REAL NOT NULL,
+	  min    REAL NOT NULL,
+	  max    REAL NOT NULL,
+	  count  INTEGER NOT NULL,
+	  PRIMARY KEY (source, day)
+	);
+	CREATE INDEX IF NOT EXISTS idx_series_daily_source_day ON series_daily(source, day);`,
 }
 
 // Open abre la BD con WAL, busy_timeout y una sola conexión escritora.
@@ -216,6 +231,45 @@ func SizeBytes(path string) int64 {
 func PurgeSeries(ctx context.Context, d *sql.DB, retentionDays int) (int64, error) {
 	res, err := d.ExecContext(ctx,
 		"DELETE FROM series WHERE ts < datetime('now', '-' || ? || ' days')", retentionDays)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// RollupSeriesToDaily agrega a series_daily (AVG/MIN/MAX por source y día)
+// todas las muestras crudas más viejas que retentionDays, y luego las borra.
+// UPSERT: re-agregar un día ya presente lo recalcula (idempotente).
+func RollupSeriesToDaily(ctx context.Context, d *sql.DB, retentionDays int) (int64, error) {
+	cutoff := "datetime('now', '-' || " + strconv.Itoa(retentionDays) + " || ' days')"
+	// 1. Agregar crudas viejas → series_daily (por source y día).
+	if _, err := d.ExecContext(ctx, `
+		INSERT INTO series_daily (source, day, avg, min, max, count)
+		SELECT source, substr(ts, 1, 10) AS day,
+		       AVG(value), MIN(value), MAX(value), COUNT(*)
+		FROM series
+		WHERE ts < `+cutoff+`
+		GROUP BY source, day
+		ON CONFLICT(source, day) DO UPDATE SET
+		  avg = (avg * count + excluded.avg * excluded.count) / (count + excluded.count),
+		  min = MIN(min, excluded.min),
+		  max = MAX(max, excluded.max),
+		  count = count + excluded.count`); err != nil {
+		return 0, err
+	}
+	// 2. Borrar las crudas ya agregadas.
+	res, err := d.ExecContext(ctx, "DELETE FROM series WHERE ts < "+cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// PurgeSeriesDaily borra agregados diarios más viejos que days (retención
+// larga: 5 años por defecto para la tendencia de capacidad).
+func PurgeSeriesDaily(ctx context.Context, d *sql.DB, days int) (int64, error) {
+	res, err := d.ExecContext(ctx,
+		"DELETE FROM series_daily WHERE day < date('now', '-' || ? || ' days')", days)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/httpapi/series.go
+++ b/internal/httpapi/series.go
@@ -8,8 +8,9 @@ import (
 )
 
 // getSeries — GET /api/series?source=pool.tank.used_pct&days=7&points=800
-// Devuelve la serie muestreada (LTTB) del rango pedido. days 1-365, points
-// 50-2000. Rango sin datos → {points: []} con 200 (un hueco es estado normal).
+// Devuelve la serie muestreada (LTTB) del rango pedido. days 1-1825 (5 años;
+// los rangos largos usan agregados diarios de series_daily), points 50-2000.
+// Rango sin datos → {points: []} con 200 (un hueco es estado normal).
 func (s *Server) getSeries(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("source")
 	if !series.ValidSource(src) {
@@ -32,7 +33,11 @@ func (s *Server) getSeries(w http.ResponseWriter, r *http.Request) {
 			points = n
 		}
 	}
-	pts, err := series.Range(r.Context(), s.db, src, from, to, points)
+	retention := s.cfg.RetentionDays
+	if retention <= 0 {
+		retention = 30
+	}
+	pts, err := series.Range(r.Context(), s.db, src, from, to, points, retention)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "db_error", err.Error())
 		return

--- a/internal/series/series.go
+++ b/internal/series/series.go
@@ -19,33 +19,105 @@ type Point struct {
 
 // Range consulta una fuente entre from y to (epoch segundos) y devuelve hasta
 // threshold puntos muestreados con LTTB. Rango vacío → slice vacío (200).
-func Range(ctx context.Context, db *sql.DB, source string, from, to int64, threshold int) ([]Point, error) {
+// Usa series_daily (agregados diarios) para la parte del rango más vieja que
+// rawRetentionDays; combina ambas consultas y ordena por ts.
+func Range(ctx context.Context, db *sql.DB, source string, from, to int64, threshold int, rawRetentionDays int) ([]Point, error) {
 	if to <= from {
 		return []Point{}, nil
 	}
+	cutoff := time.Now().UTC().Add(-time.Duration(rawRetentionDays) * 24 * time.Hour).Unix()
+	raw := []Point{}
+	if to > cutoff {
+		rawStart := from
+		if rawStart < cutoff {
+			rawStart = cutoff
+		}
+		var err error
+		raw, err = rangeTable(ctx, db, source, rawStart, to)
+		if err != nil {
+			return nil, err
+		}
+	}
+	daily := []Point{}
+	if from < cutoff {
+		dailyEnd := to
+		if dailyEnd > cutoff {
+			dailyEnd = cutoff
+		}
+		var err error
+		daily, err = rangeDaily(ctx, db, source, from, dailyEnd)
+		if err != nil {
+			return nil, err
+		}
+	}
+	merged := mergePoints(daily, raw)
+	if len(merged) <= threshold {
+		return merged, nil
+	}
+	return LTTB(merged, threshold), nil
+}
+
+// rangeTable consulta las muestras crudas de series.
+func rangeTable(ctx context.Context, db *sql.DB, source string, from, to int64) ([]Point, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT CAST(strftime('%s', ts) AS INTEGER), value FROM series
-		 WHERE source = ? AND ts >= datetime(?, 'unixepoch') AND ts <= datetime(?, 'unixepoch')
+		 WHERE source = ? AND ts >= datetime(?, 'unixepoch') AND ts < datetime(?, 'unixepoch')
 		 ORDER BY ts`, source, from, to)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	raw := make([]Point, 0, 256)
+	out := []Point{}
 	for rows.Next() {
 		var p Point
 		if err := rows.Scan(&p.Ts, &p.Value); err != nil {
 			return nil, err
 		}
-		raw = append(raw, p)
+		out = append(out, p)
 	}
-	if err := rows.Err(); err != nil {
+	return out, rows.Err()
+}
+
+// rangeDaily consulta los agregados diarios (series_daily). El punto diario se
+// sitúa a mediodía UTC del día (timestamp representativo de la media).
+func rangeDaily(ctx context.Context, db *sql.DB, source string, from, to int64) ([]Point, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT CAST(strftime('%s', day || 'T12:00:00Z') AS INTEGER), avg FROM series_daily
+		 WHERE source = ? AND day >= date(?, 'unixepoch') AND day < date(?, 'unixepoch')
+		 ORDER BY day`, source, from, to)
+	if err != nil {
 		return nil, err
 	}
-	if len(raw) <= int(threshold) {
-		return raw, nil
+	defer rows.Close()
+	out := []Point{}
+	for rows.Next() {
+		var p Point
+		if err := rows.Scan(&p.Ts, &p.Value); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
 	}
-	return LTTB(raw, threshold), nil}
+	return out, rows.Err()
+}
+
+// mergePoints fusiona dos series ya ordenadas por ts (daily primero, luego
+// raw), evitando duplicados en la frontera del cutoff.
+func mergePoints(a, b []Point) []Point {
+	out := make([]Point, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i].Ts <= b[j].Ts {
+			out = append(out, a[i])
+			i++
+		} else {
+			out = append(out, b[j])
+			j++
+		}
+	}
+	out = append(out, a[i:]...)
+	out = append(out, b[j:]...)
+	return out
+}
 
 // LTTB — Largest-Triangle-Three-Buckets: conserva la forma visual (picos y
 // valles) reduciendo la serie a `threshold` puntos. Adaptado del asset Go de
@@ -109,10 +181,11 @@ func ValidSource(src string) bool {
 	return false
 }
 
-// ParseDays convierte el parámetro ?days= a rango epoch. Acepta 1-365.
+// ParseDays convierte el parámetro ?days= a rango epoch. Acepta 1-1825
+// (5 años de tendencia diaria; la retención larga la garantiza series_daily).
 func ParseDays(days int) (from, to int64, err error) {
-	if days < 1 || days > 365 {
-		return 0, 0, fmt.Errorf("days fuera de rango (1-365): %d", days)
+	if days < 1 || days > 1825 {
+		return 0, 0, fmt.Errorf("days fuera de rango (1-1825): %d", days)
 	}
 	now := time.Now().UTC()
 	to = now.Unix()

--- a/internal/series/series_test.go
+++ b/internal/series/series_test.go
@@ -3,6 +3,7 @@ package series
 import (
 	"context"
 	"testing"
+	"time"
 
 	"easyzfs/internal/db"
 )
@@ -12,7 +13,7 @@ import (
 func TestLTTB_Reduce(t *testing.T) {
 	data := make([]Point, 100)
 	for i := range data {
-		data[i] = Point{Ts: int64(i), Value: float64(i*i % 37)}
+		data[i] = Point{Ts: int64(i), Value: float64(i * i % 37)}
 	}
 	got := LTTB(data, 10)
 	if len(got) != 10 {
@@ -38,6 +39,8 @@ func TestLTTB_NoReduce(t *testing.T) {
 }
 
 // Range filtra por fuente y ventana de tiempo y aplica LTTB.
+// Las muestras usan ts RELATIVOS al presente (dentro de la retención raw),
+// porque fuera de ella Range consulta series_daily (test aparte).
 func TestRange_FiltraYDowsample(t *testing.T) {
 	d, err := db.Open(t.TempDir() + "/test.db")
 	if err != nil {
@@ -47,9 +50,11 @@ func TestRange_FiltraYDowsample(t *testing.T) {
 	if err := db.Migrate(context.Background(), d); err != nil {
 		t.Fatal(err)
 	}
-	// 200 muestras de pool.tank.used_pct (una por "minuto" en epoch)
+	now := time.Now().UTC()
+	base := now.Add(-200 * time.Minute)
+	// 200 muestras de pool.tank.used_pct (una por "minuto")
 	for i := 0; i < 200; i++ {
-		ts := int64(1_700_000_000 + i*60)
+		ts := base.Add(time.Duration(i) * time.Minute).Unix()
 		if _, err := d.Exec(
 			"INSERT INTO series(source, ts, value) VALUES (?, datetime(?, 'unixepoch'), ?)",
 			"pool.tank.used_pct", ts, float64(i)); err != nil {
@@ -57,10 +62,10 @@ func TestRange_FiltraYDowsample(t *testing.T) {
 		}
 	}
 	// una muestra de otra fuente que NO debe colarse
-	d.Exec("INSERT INTO series(source, ts, value) VALUES ('disk.sda.temp', datetime(1700000060, 'unixepoch'), 42)")
+	d.Exec("INSERT INTO series(source, ts, value) VALUES ('disk.sda.temp', datetime(?, 'unixepoch'), 42)", base.Add(10*time.Minute).Unix())
 
-	from, to := int64(1_700_000_000), int64(1_700_000_000+199*60)
-	got, err := Range(context.Background(), d, "pool.tank.used_pct", from, to, 50)
+	from, to := base.Unix(), now.Unix()
+	got, err := Range(context.Background(), d, "pool.tank.used_pct", from, to, 50, 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,9 +76,10 @@ func TestRange_FiltraYDowsample(t *testing.T) {
 		t.Fatalf("downsampling no aplicó: %d > 50", len(got))
 	}
 	// el rango excluye la muestra de otra fuente (solo pool.tank.used_pct)
+	intruderTS := base.Add(10 * time.Minute).Unix()
 	for _, p := range got {
-		if p.Value == 42 && p.Ts == 1700000060 {
-			t.Errorf("se coló una muestra de otra fuente")
+		if p.Ts == intruderTS {
+			t.Errorf("se coló una muestra de otra fuente (ts=%d)", intruderTS)
 		}
 	}
 }
@@ -88,7 +94,7 @@ func TestRange_Vacio(t *testing.T) {
 	if err := db.Migrate(context.Background(), d); err != nil {
 		t.Fatal(err)
 	}
-	got, err := Range(context.Background(), d, "pool.tank.used_pct", 100, 200, 50)
+	got, err := Range(context.Background(), d, "pool.tank.used_pct", 100, 200, 50, 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,13 +115,19 @@ func TestParseDays(t *testing.T) {
 	if _, _, err := ParseDays(0); err == nil {
 		t.Error("days=0 debería fallar")
 	}
-	if _, _, err := ParseDays(400); err == nil {
-		t.Error("days=400 debería fallar")
+	if _, _, err := ParseDays(2000); err == nil {
+		t.Error("days=2000 debería fallar (máx 1825)")
+	}
+	if _, _, err := ParseDays(1825); err != nil {
+		t.Errorf("days=1825 debería ser válido: %v", err)
 	}
 }
 
 func TestValidSource(t *testing.T) {
-	for _, ok := range []struct{ src string; want bool }{
+	for _, ok := range []struct {
+		src  string
+		want bool
+	}{
 		{"pool.tank.used_pct", true},
 		{"disk.sda.temp", true},
 		{"pool..bad", false},
@@ -126,5 +138,108 @@ func TestValidSource(t *testing.T) {
 		if got := ValidSource(ok.src); got != ok.want {
 			t.Errorf("ValidSource(%q) = %v, esperado %v", ok.src, got, ok.want)
 		}
+	}
+}
+
+// RollupSeriesToDaily agrega a series_daily las crudas viejas y las borra.
+func TestRollupYRangeDiario(t *testing.T) {
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	// 40 días atrás: 4 muestras del mismo día (deben agregarse a daily).
+	old := now.AddDate(0, 0, -40)
+	for i, v := range []float64{10, 20, 30, 40} {
+		ts := time.Date(old.Year(), old.Month(), old.Day(), 1+i, 0, 0, 0, time.UTC)
+		if _, err := d.Exec(
+			"INSERT INTO series(source, ts, value) VALUES (?, datetime(?, 'unixepoch'), ?)",
+			"pool.tank.used_pct", ts.Unix(), v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 1 día atrás: cruda que NO debe agregarse (dentro de retención 30d).
+	recent := now.AddDate(0, 0, -1)
+	if _, err := d.Exec(
+		"INSERT INTO series(source, ts, value) VALUES (?, datetime(?, 'unixepoch'), 55)",
+		"pool.tank.used_pct", recent.Unix()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.RollupSeriesToDaily(context.Background(), d, 30); err != nil {
+		t.Fatal(err)
+	}
+
+	// La cruda vieja se borró; la reciente sigue.
+	var nRecent int
+	d.QueryRow("SELECT COUNT(*) FROM series WHERE source='pool.tank.used_pct'").Scan(&nRecent)
+	if nRecent != 1 {
+		t.Fatalf("quedan %d crudas, esperado 1 (solo la reciente)", nRecent)
+	}
+	// series_daily tiene 1 día con avg 25, min 10, max 40.
+	var avg, min, max float64
+	if err := d.QueryRow(
+		"SELECT avg, min, max FROM series_daily WHERE source='pool.tank.used_pct'").Scan(&avg, &min, &max); err != nil {
+		t.Fatal(err)
+	}
+	if avg != 25 || min != 10 || max != 40 {
+		t.Fatalf("agregado %v/%v/%v, esperado 25/10/40", avg, min, max)
+	}
+
+	// Range con rango largo (50 días) combina daily + raw y no rompe.
+	from := now.AddDate(0, 0, -50).Unix()
+	to := now.Unix()
+	pts, err := Range(context.Background(), d, "pool.tank.used_pct", from, to, 100, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) < 2 {
+		t.Fatalf("rango largo con %d puntos, esperado >= 2 (daily + raw)", len(pts))
+	}
+	// El punto diario es el mediodía UTC: ts ~ old-day 12:00.
+	foundDaily := false
+	for _, p := range pts {
+		if p.Value == 25 {
+			foundDaily = true
+		}
+	}
+	if !foundDaily {
+		t.Error("no aparece el agregado diario (25) en el rango largo")
+	}
+}
+
+// Range con rango corto (dentro de retención) no toca series_daily.
+func TestRangeCortoNoUsaDaily(t *testing.T) {
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	// Cruda reciente.
+	if _, err := d.Exec(
+		"INSERT INTO series(source, ts, value) VALUES ('pool.tank.used_pct', datetime(?, 'unixepoch'), 42)",
+		now.Add(-time.Hour).Unix()); err != nil {
+		t.Fatal(err)
+	}
+	// Un daily de una fuente distinta que no debe colarse.
+	if _, err := d.Exec(
+		"INSERT INTO series_daily(source, day, avg, min, max, count) VALUES ('disk.sda.temp', ?, 99, 99, 99, 1)",
+		now.AddDate(0, 0, -60).Format("2006-01-02")); err != nil {
+		t.Fatal(err)
+	}
+	pts, err := Range(context.Background(), d, "pool.tank.used_pct", now.Add(-2*24*time.Hour).Unix(), now.Unix(), 100, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 1 || pts[0].Value != 42 {
+		t.Fatalf("rango corto devolvió %v, esperado solo la cruda 42", pts)
 	}
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import type { ComponentType } from 'react';
 import { AppProvider, useApp, alertTargetView } from './ui/store';
 import type { ViewId } from './ui/store';
 import { ModalProvider, ModalHost } from './components/ModalHost';
-import { Logo, IconHome, IconPool, IconData, IconSnap, IconTask, IconDisk, IconGear, IconBell, IconMoon, IconSun, IconMonitor, IconChev, IconFoldLeft, IconFoldRight, IconUser } from './components/icons';
+import { Logo, IconHome, IconPool, IconData, IconSnap, IconTask, IconDisk, IconGear, IconBell, IconMoon, IconSun, IconMonitor, IconChev, IconFoldLeft, IconFoldRight, IconUser, IconList } from './components/icons';
 import { Spinner } from './components/ui';
 import ErrorBoundary from './components/ErrorBoundary';
 import PullToRefresh from './components/PullToRefresh';
@@ -27,6 +27,7 @@ const Datasets = lazyRetry(() => import('./views/Datasets'));
 const Snapshots = lazyRetry(() => import('./views/Snapshots'));
 const Tasks = lazyRetry(() => import('./views/Tasks'));
 const Disks = lazyRetry(() => import('./views/Disks'));
+const Trends = lazyRetry(() => import('./views/Trends'));
 const Settings = lazyRetry(() => import('./views/Settings'));
 
 // Nav principal (Ajustes NO va aquí: vive al pie del sidebar, patrón
@@ -38,6 +39,7 @@ const NAV: { id: ViewId; icon: ComponentType<{ size?: number }> }[] = [
   { id: 'disks', icon: IconDisk },
   { id: 'tasks', icon: IconTask },
   { id: 'snaps', icon: IconSnap },
+  { id: 'trends', icon: IconList },
 ];
 
 const COLLAPSED_KEY = 'easyzfs-sidebar-collapsed';
@@ -196,6 +198,7 @@ function Shell() {
       case 'snaps': return <Snapshots />;
       case 'tasks': return <Tasks />;
       case 'disks': return <Disks />;
+      case 'trends': return <Trends />;
       case 'settings': return <Settings />;
     }
   })();

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -855,3 +855,19 @@ html.reduce-motion *{transition:none!important;animation:none!important}
     opacity: 0.7;
   }
 }
+
+/* ---- Tendencias (#85) ---- */
+.tr-controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 14px; }
+.tr-src { flex: 1; min-width: 200px; max-width: 420px; }
+.tr-ranges { display: inline-flex; border: 1px solid var(--border); border-radius: 9px; overflow: hidden; }
+.tr-range { padding: 6px 12px; font-size: 12.5px; font-weight: 700; background: transparent; color: var(--muted); border: none; cursor: pointer; }
+.tr-range:hover { background: var(--surface2); }
+.tr-range.active { background: var(--accent); color: #fff; }
+.tr-card { padding: 14px; }
+.tr-plot svg { min-height: 160px; }
+@media (max-width: 640px) {
+  .tr-controls { flex-direction: column; align-items: stretch; }
+  .tr-src { max-width: none; }
+  .tr-ranges { justify-content: space-between; }
+  .tr-range { flex: 1; text-align: center; padding: 8px 4px; }
+}

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -81,6 +81,19 @@ const es = {
   dash_alerts: 'Alertas recientes', dash_activity: 'Actividad',
   dash_no_alerts: 'Sin alertas. Todo en orden.',
 
+  // Tendencias (#85)
+  tr_title: 'Tendencias',
+  tr_sub: 'Evolución histórica de la capacidad de tus pools y la temperatura de tus discos. Los rangos largos usan agregados diarios.',
+  tr_source: 'Fuente',
+  tr_select: 'Elige una fuente…',
+  tr_range: 'Rango',
+  tr_pools: 'pools',
+  tr_disks: 'discos',
+  tr_error: 'No se pudieron cargar los datos',
+  tr_empty: 'Sin datos en este rango. Se irán acumulando con el tiempo.',
+  tr_chart: 'Gráfica de tendencia',
+  tr_last: 'Último valor',
+
   // Pools
   pools_all: 'Todos', pools_ok: 'Sanos', pools_warn: 'Con avisos',
   pool_create: '+ Crear pool', pool_import: 'Importar pool existente',
@@ -616,6 +629,19 @@ const en: Record<I18nKey, string> = {
   dash_pools: 'Pools', dash_see_all: 'View all',
   dash_alerts: 'Recent alerts', dash_activity: 'Activity',
   dash_no_alerts: 'No alerts. Everything is fine.',
+
+  // Trends (#85)
+  tr_title: 'Trends',
+  tr_sub: 'Historical evolution of your pool capacity and disk temperatures. Long ranges use daily aggregates.',
+  tr_source: 'Source',
+  tr_select: 'Pick a source…',
+  tr_range: 'Range',
+  tr_pools: 'pools',
+  tr_disks: 'disks',
+  tr_error: 'Could not load the data',
+  tr_empty: 'No data in this range. It will accumulate over time.',
+  tr_chart: 'Trend chart',
+  tr_last: 'Last value',
 
   pools_all: 'All', pools_ok: 'Healthy', pools_warn: 'With warnings',
   pool_create: '+ Create pool', pool_import: 'Import existing pool',

--- a/web/src/ui/store.tsx
+++ b/web/src/ui/store.tsx
@@ -13,8 +13,8 @@ import type { LangMode, I18nKey } from './i18n';
 import { applyTheme, applyDensity, applyReduceMotion, onThemeChange, startThemeWatcher, effectiveTheme, setThemeMode, getThemeMode } from './theme';
 import type { ThemeMode } from './theme';
 
-export type ViewId = 'dash' | 'pools' | 'data' | 'snaps' | 'tasks' | 'disks' | 'settings';
-export const VIEWS: ViewId[] = ['dash', 'pools', 'data', 'snaps', 'tasks', 'disks', 'settings'];
+export type ViewId = 'dash' | 'pools' | 'data' | 'snaps' | 'tasks' | 'disks' | 'trends' | 'settings';
+export const VIEWS: ViewId[] = ['dash', 'pools', 'data', 'snaps', 'tasks', 'disks', 'trends', 'settings'];
 
 function parseHash(): ViewId {
   const h = location.hash.replace(/^#\/?/, '') as ViewId;

--- a/web/src/views/Trends.tsx
+++ b/web/src/views/Trends.tsx
@@ -1,0 +1,145 @@
+// Vista Tendencias: evolución histórica de capacidad de pools (used_pct) y
+// temperatura de discos (temp) con rangos de 7 días a 5 años. Los rangos
+// largos usan agregados diarios del servidor (series_daily, #85).
+import { useMemo, useState } from 'react';
+import { useApp } from '../ui/store';
+import { useData } from '../ui/useData';
+import { getProvider } from '../data';
+import type { SeriesResp } from '../data/types';
+
+const RANGES: { days: number; label: string }[] = [
+  { days: 7, label: '7d' },
+  { days: 30, label: '30d' },
+  { days: 90, label: '90d' },
+  { days: 365, label: '1y' },
+  { days: 1825, label: '5y' },
+];
+
+export default function Trends() {
+  const { t } = useApp();
+  const pools = useData((p) => p.getPools());
+  const disks = useData((p) => p.getDisks());
+
+  // Fuente seleccionada: pool.<name>.used_pct | disk.<dev>.temp
+  const [source, setSource] = useState('');
+  const [days, setDays] = useState(30);
+
+  const series = useData(
+    (p) => (source ? p.getSeries(source, days) : Promise.resolve({ source, points: [] } as SeriesResp)),
+    [source, days],
+  );
+
+  // Opciones de fuente: pools primero, luego discos con sensor.
+  const options = useMemo(() => {
+    const out: { value: string; label: string; group: string }[] = [];
+    for (const po of pools.data ?? []) {
+      out.push({ value: `pool.${po.name}.used_pct`, label: po.name, group: t('tr_pools') });
+    }
+    for (const d of disks.data ?? []) {
+      if (d.temp_c != null) {
+        out.push({ value: `disk.${d.dev}.temp`, label: `${d.dev} · ${d.model}`, group: t('tr_disks') });
+      }
+    }
+    return out;
+  }, [pools.data, disks.data, t]);
+
+  // Si no hay fuente y ya hay opciones, preseleccionar la primera.
+  if (!source && options.length > 0) {
+    setTimeout(() => setSource(options[0].value), 0);
+  }
+
+  return (
+    <section className="blk">
+      <h2 style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-.02em' }}>{t('tr_title')}</h2>
+      <p className="muted" style={{ margin: '4px 0 16px' }}>{t('tr_sub')}</p>
+
+      <div className="tr-controls">
+        <select className="tr-src" value={source} onChange={(e) => setSource(e.target.value)}
+          aria-label={t('tr_source')}>
+          {!source && <option value="">{t('tr_select')}</option>}
+          {options.map((o: { value: string; label: string; group: string }) => (
+            <option key={o.value} value={o.value}>{o.label} ({o.group})</option>
+          ))}
+        </select>
+        <div className="tr-ranges" role="group" aria-label={t('tr_range')}>
+          {RANGES.map((r) => (
+            <button key={r.days} type="button"
+              className={`tr-range${days === r.days ? ' active' : ''}`}
+              onClick={() => setDays(r.days)}>
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="card pad tr-card">
+        {series.loading && <p className="muted">{t('loading')}</p>}
+        {!series.loading && !!series.error && (
+          <p className="form-err" role="alert">{t('tr_error')}</p>
+        )}
+        {!series.loading && !series.error && (
+          <TrendChart points={series.data?.points ?? []} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+// TrendChart — gráfica de área SVG pura (sin librerías): línea + relleno
+// degradado + etiquetas de eje Y (máx/mín) y del último valor.
+function TrendChart({ points }: { points: SeriesResp['points'] }) {
+  const { t } = useApp();
+  const W = 760, H = 240, PAD = 12;
+  const last = points[points.length - 1];
+
+  if (points.length < 2) {
+    return <p className="muted" style={{ padding: 40, textAlign: 'center' }}>{t('tr_empty')}</p>;
+  }
+
+  const xs = points.map((p) => p.ts);
+  const ys = points.map((p) => p.value);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const rangeX = maxX - minX || 1;
+  const rangeY = maxY - minY || 1;
+  const X = (ts: number) => PAD + ((ts - minX) / rangeX) * (W - PAD * 2);
+  const Y = (v: number) => H - PAD - ((v - minY) / rangeY) * (H - PAD * 2);
+  const line = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${X(p.ts).toFixed(1)},${Y(p.value).toFixed(1)}`).join(' ');
+  const area = `${line} L${X(maxX).toFixed(1)},${H - PAD} L${X(minX).toFixed(1)},${H - PAD} Z`;
+
+  const fmtY = (v: number) => (v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`);
+  const fmtT = (ts: number) => new Date(ts * 1000).toLocaleDateString();
+
+  return (
+    <div className="tr-plot">
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label={t('tr_chart')}
+        style={{ width: '100%', height: 'auto', display: 'block' }}>
+        <defs>
+          <linearGradient id="trFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.35" />
+            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.04" />
+          </linearGradient>
+        </defs>
+        <path d={area} fill="url(#trFill)" />
+        <path d={line} fill="none" stroke="var(--accent)" strokeWidth="2"
+          strokeLinejoin="round" strokeLinecap="round" />
+        <text x={PAD} y={PAD + 4} fontSize="11" fill="var(--muted)" fontWeight={700}>
+          {fmtY(maxY)}
+        </text>
+        <text x={PAD} y={H - PAD - 4} fontSize="11" fill="var(--muted)" fontWeight={700}>
+          {fmtY(minY)}
+        </text>
+        {last && (
+          <text x={W - PAD} y={PAD + 4} fontSize="11" fill="var(--accent)" fontWeight={800} textAnchor="end">
+            {fmtY(last.value)}
+          </text>
+        )}
+      </svg>
+      {last && (
+        <div className="muted" style={{ fontSize: 12, marginTop: 4 }}>
+          {t('tr_last')}: <b style={{ color: 'var(--text)' }}>{fmtY(last.value)}</b> · {fmtT(last.ts)}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #85

## What

- Backend: migration v20 adds `series_daily` (AVG/MIN/MAX per source and day). The maintenance collector rolls up raw samples older than the retention window into daily aggregates BEFORE purging them (idempotent UPSERT, 5-year retention).
- `GET /api/series` now accepts `days` up to 1825 (5y) and merges daily aggregates with raw samples across the cutoff, keeping LTTB downsampling.
- Frontend: new Trends view (sidebar/bottom-nav) with source picker (pools used_pct, disks temp), range buttons (7d/30d/90d/1y/5y) and a dependency-free SVG area chart (ES/EN).

## Tests

- series: rollup to daily (avg/min/max, raw cleanup, long-range merge), short range does not touch daily, ParseDays 1-1825.
- Full Go suite green. Playwright 8/8 (demo: sources populated, chart renders, ranges switch, no overflow).