### PR TITLE
feat(alerts): add ntfy, Gotify and syslog notification channels

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"time"
 
+	"easyzfs/internal/channels"
 	"easyzfs/internal/hub"
 	"easyzfs/internal/model"
 	"easyzfs/internal/notifier"
@@ -25,9 +26,10 @@ type Alerter struct {
 	db   *sql.DB
 	hub  *hub.Hub
 	st   *settings.Store
-	push *push.Sender // puede ser nil (push no configurado)
+	push *push.Sender      // puede ser nil (push no configurado)
 	wh   *webhook.Notifier // puede ser nil (webhook desactivado)
 	mail *notifier.Mailer  // puede ser nil (email desactivado)
+	ch   *channels.Client  // puede ser nil (ntfy/gotify/syslog desactivados)
 }
 
 // New crea el Alerter.
@@ -44,6 +46,9 @@ func (a *Alerter) SetWebhook(w *webhook.Notifier) { a.wh = w }
 
 // SetEmail conecta el canal de email (opcional; nil = sin email).
 func (a *Alerter) SetEmail(m *notifier.Mailer) { a.mail = m }
+
+// SetChannels conecta los canales ntfy/gotify/syslog (opcional; nil = sin ellos).
+func (a *Alerter) SetChannels(c *channels.Client) { a.ch = c }
 
 // Raise inserta una alerta sin metadatos estructurados (kind "").
 func (a *Alerter) Raise(ctx context.Context, level, source, target, message string) {
@@ -115,6 +120,11 @@ func (a *Alerter) RaiseKind(ctx context.Context, level, source, target, message,
 	if a.mail != nil && kind != "" {
 		go a.notifyEmail(level, source, target, kind, params, now)
 	}
+	// Canales ntfy/gotify/syslog: un solo destino configurado por env, texto
+	// compuesto en el idioma por defecto (es_ES). Best-effort async.
+	if a.ch != nil && a.ch.Enabled() && kind != "" {
+		go a.notifyChannels(level, source, target, kind, params, now)
+	}
 	// Push (app cerrada): fire-and-forget; el sender decide a quién y nunca falla.
 	if a.push != nil && kind != "" {
 		go a.push.Notify(context.Background(),
@@ -163,6 +173,25 @@ func (a *Alerter) notifyEmail(level, source, target, kind string, params map[str
 			log.Printf("alerts: email a usuario %s: %v", d.user, err)
 		}
 	}
+}
+
+// notifyChannels envía la alerta a los canales genéricos (ntfy/gotify/syslog).
+// Texto compuesto con el catálogo i18n del push en español por defecto; los
+// canales son de infraestructura (un destino), no por usuario.
+func (a *Alerter) notifyChannels(level, source, target, kind string, params map[string]any, ts time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	title, body := push.Compose("es", kind, params)
+	prefix := ""
+	switch level {
+	case "crit":
+		prefix = "🔴 "
+	case "warn":
+		prefix = "🟠 "
+	default:
+		prefix = "🔵 "
+	}
+	a.ch.Send(ctx, prefix+title, fmt.Sprintf("[%s] %s", level, body))
 }
 
 // emailTypeEnabled — ¿el usuario tiene habilitado este tipo de alerta por

--- a/internal/alerts/alerts_test.go
+++ b/internal/alerts/alerts_test.go
@@ -69,7 +69,7 @@ func TestRaise_DedupeLegado(t *testing.T) {
 	ctx := context.Background()
 
 	a.Raise(ctx, "info", "test.legado", "", "mensaje fijo")
-	a.Raise(ctx, "info", "test.legado", "", "mensaje fijo")   // duplicada: se ignora
+	a.Raise(ctx, "info", "test.legado", "", "mensaje fijo")     // duplicada: se ignora
 	a.Raise(ctx, "info", "test.legado", "", "mensaje distinto") // nueva: entra
 
 	var n int

--- a/internal/alerts/channels_test.go
+++ b/internal/alerts/channels_test.go
@@ -1,0 +1,94 @@
+// channels_test.go (alerts) — integración: RaiseKind entrega la alerta a los
+// canales ntfy/gotify/syslog configurados (best-effort async).
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"easyzfs/internal/channels"
+	"easyzfs/internal/db"
+	"easyzfs/internal/hub"
+	"easyzfs/internal/settings"
+)
+
+func TestRaiseKind_EnviaCanales(t *testing.T) {
+	d, err := db.Open(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	if err := db.Migrate(context.Background(), d); err != nil {
+		t.Fatal(err)
+	}
+	st, err := settings.NewStore(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Servidor fake ntfy que captura el payload.
+	type recv struct {
+		title, msg string
+	}
+	got := make(chan recv, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- recv{title: p["title"], msg: p["message"]}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := channels.New(srv.URL, "", "", "", "", 0, "udp", 1)
+	a := New(d, hub.NewHub(), st)
+	a.SetChannels(c)
+	a.RaiseKind(context.Background(), "warn", "pool.tank", "pools:tank",
+		"Pool tank al 95% de capacidad", "pool_capacity",
+		map[string]any{"pool": "tank", "pct": 95, "threshold": 90})
+
+	select {
+	case m := <-got:
+		if m.title == "" || m.msg == "" {
+			t.Fatalf("payload incompleto: %+v", m)
+		}
+		if !containsFold(m.msg, "tank") {
+			t.Errorf("mensaje sin pool: %q", m.msg)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("no llegó alerta al canal ntfy")
+	}
+}
+
+func containsFold(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if stringsEqualFold(s[i:i+len(sub)], sub) {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+func stringsEqualFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/channels/channels.go
+++ b/internal/channels/channels.go
@@ -1,0 +1,166 @@
+// Package channels — canales de alerta adicionales (#86): ntfy, Gotify y
+// Syslog. Cada canal es inerte si no está configurado (env). Envíos
+// best-effort con timeout acotado; los fallos se loguean y no rompen nada.
+package channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Client — conjunto de canales configurados. Los nil no envían.
+type Client struct {
+	ntfyURL   string
+	ntfyToken string
+
+	gotifyURL   string
+	gotifyToken string
+
+	syslogHost     string
+	syslogPort     int
+	syslogProto    string
+	syslogFacility int
+
+	http *http.Client
+}
+
+// New construye el cliente a partir de la configuración. Solo registra los
+// canales con los datos mínimos; el resto queda nil (inactivo).
+func New(ntfyURL, ntfyToken, gotifyURL, gotifyToken string,
+	syslogHost string, syslogPort int, syslogProto string, syslogFacility int) *Client {
+	return &Client{
+		ntfyURL:        ntfyURL,
+		ntfyToken:      ntfyToken,
+		gotifyURL:      gotifyURL,
+		gotifyToken:    gotifyToken,
+		syslogHost:     syslogHost,
+		syslogPort:     syslogPort,
+		syslogProto:    syslogProto,
+		syslogFacility: syslogFacility,
+		http:           &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Enabled — ¿hay al menos un canal configurado?
+func (c *Client) Enabled() bool {
+	return c != nil && (c.ntfyURL != "" || c.gotifyURL != "" || c.syslogHost != "")
+}
+
+// Send entrega la alerta a todos los canales configurados (best-effort).
+// El contexto lleva timeout; cada canal se envía en serie con su propio
+// límite. Compose recibe el texto ya compuesto (título + cuerpo).
+func (c *Client) Send(ctx context.Context, title, body string) {
+	if c == nil {
+		return
+	}
+	if c.ntfyURL != "" {
+		c.sendNtfy(ctx, title, body)
+	}
+	if c.gotifyURL != "" {
+		c.sendGotify(ctx, title, body)
+	}
+	if c.syslogHost != "" {
+		c.sendSyslog(ctx, title, body)
+	}
+}
+
+// sendNtfy — POST JSON a NTFY_URL con Authorization Bearer si hay token.
+// Formato: {"topic":…} se envía a la URL base del topic directamente:
+// la URL configurada es el topic completo (p.ej. https://ntfy.sh/mialerta).
+func (c *Client) sendNtfy(ctx context.Context, title, body string) {
+	payload, err := json.Marshal(map[string]string{
+		"title":   title,
+		"message": body,
+	})
+	if err != nil {
+		log.Printf("channels: ntfy: marshal: %v", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ntfyURL, bytes.NewReader(payload))
+	if err != nil {
+		log.Printf("channels: ntfy: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.ntfyToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.ntfyToken)
+	}
+	if err := c.do(req); err != nil {
+		log.Printf("channels: ntfy: %v", err)
+	}
+}
+
+// sendGotify — POST JSON a GOTIFY_URL/message con X-Gotify-Key.
+func (c *Client) sendGotify(ctx context.Context, title, body string) {
+	payload, err := json.Marshal(map[string]string{
+		"title":    title,
+		"message":  body,
+		"priority": "5",
+	})
+	if err != nil {
+		log.Printf("channels: gotify: marshal: %v", err)
+		return
+	}
+	url := c.gotifyURL + "/message"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		log.Printf("channels: gotify: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Gotify-Key", c.gotifyToken)
+	if err := c.do(req); err != nil {
+		log.Printf("channels: gotify: %v", err)
+	}
+}
+
+// sendSyslog — datagrama RFC 3164 (PRI + timestamp + host + texto) por UDP/TCP.
+func (c *Client) sendSyslog(ctx context.Context, title, body string) {
+	// facility*8 + severity(1=notice); fallback 14 (1*8+1=9 → user.notice).
+	pri := c.syslogFacility*8 + 1
+	msg := fmt.Sprintf("<%d>%s EasyZFS[%d]: %s: %s",
+		pri, time.Now().Format("Jan _2 15:04:05"), 0, title, body)
+	addr := fmt.Sprintf("%s:%d", c.syslogHost, c.syslogPort)
+	if c.syslogProto == "tcp" {
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			log.Printf("channels: syslog tcp: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, err := conn.Write([]byte(msg + "\n")); err != nil {
+			log.Printf("channels: syslog tcp: %v", err)
+		}
+		return
+	}
+	// UDP: dial y close por envío (sin conexión persistente).
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		log.Printf("channels: syslog udp: %v", err)
+		return
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte(msg + "\n")); err != nil {
+		log.Printf("channels: syslog udp: %v", err)
+	}
+}
+
+// do ejecuta la petición y verifica 2xx; el cuerpo se cierra siempre.
+func (c *Client) do(req *http.Request) error {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/channels/channels_test.go
+++ b/internal/channels/channels_test.go
@@ -1,0 +1,131 @@
+// channels_test.go — tests de los canales ntfy/gotify/syslog con destinos de
+// prueba (httptest + listener UDP) para verificar payloads y cabeceras.
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ntfy recibe POST en / con Authorization Bearer.
+func TestNtfy(t *testing.T) {
+	var got map[string]string
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("método %s, esperado POST", r.Method)
+		}
+		auth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "", "", "", 0, "udp", 1)
+	if !c.Enabled() {
+		t.Fatal("con ntfy URL debería estar enabled")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c.Send(ctx, "Título", "Cuerpo")
+
+	if got["title"] != "Título" || got["message"] != "Cuerpo" {
+		t.Fatalf("payload ntfy inesperado: %v", got)
+	}
+	if auth != "Bearer tok123" {
+		t.Fatalf("auth %q, esperado Bearer tok123", auth)
+	}
+}
+
+// gotify recibe POST en /message con X-Gotify-Key.
+func TestGotify(t *testing.T) {
+	var got map[string]string
+	var key string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/message" {
+			t.Errorf("path %q, esperado /message", r.URL.Path)
+		}
+		key = r.Header.Get("X-Gotify-Key")
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New("", "", srv.URL, "apptok", "", 0, "udp", 1)
+	if !c.Enabled() {
+		t.Fatal("con gotify URL debería estar enabled")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c.Send(ctx, "Título", "Cuerpo")
+
+	if got["message"] != "Cuerpo" {
+		t.Fatalf("payload gotify inesperado: %v", got)
+	}
+	if key != "apptok" {
+		t.Fatalf("X-Gotify-Key %q, esperado apptok", key)
+	}
+}
+
+// syslog UDP: el datagrama llega con PRI y texto.
+func TestSyslogUDP(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().String()
+	host, portStr, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+
+	c := New("", "", "", "", host, port, "udp", 1)
+	if !c.Enabled() {
+		t.Fatal("con syslog host debería estar enabled")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c.Send(ctx, "Título", "Cuerpo")
+
+	_ = pc.SetReadDeadline(time.Now().Add(3 * time.Second))
+	buf := make([]byte, 2048)
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := string(buf[:n])
+	if !strings.HasPrefix(msg, "<9>") { // facility 1*8 + severity 1 = 9
+		t.Fatalf("PRI inesperado: %q", msg[:4])
+	}
+	if !strings.Contains(msg, "Título: Cuerpo") {
+		t.Fatalf("contenido inesperado: %q", msg)
+	}
+}
+
+// sin configuración: Enabled false y Send no rompe.
+func TestDisabled(t *testing.T) {
+	c := New("", "", "", "", "", 0, "udp", 1)
+	if c.Enabled() {
+		t.Fatal("sin canales no debería estar enabled")
+	}
+	c.Send(context.Background(), "t", "b") // no debe panickear
+	if c == nil {
+		t.Fatal("nil")
+	}
+	nilClient := (*Client)(nil)
+	nilClient.Send(context.Background(), "t", "b") // no debe panickear
+}
+
+// fallo del destino: log y sigue, sin panic.
+func TestSendErrorNoPanic(t *testing.T) {
+	c := New("http://127.0.0.1:1/no", "", "", "", "", 0, "udp", 1) // puerto 1: nada escucha
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	c.Send(ctx, "t", "b")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,14 +31,24 @@ type Config struct {
 	WebhookRetries int           // WEBHOOK_RETRIES (def 3)
 
 	// Email/SMTP (canal de alertas S5). Vacio = email desactivado.
-	SMTPHost       string // SMTP_HOST
-	SMTPPort       int    // SMTP_PORT (def 587)
-	SMTPUser       string // SMTP_USER (vacío = SMTP sin autenticación)
-	SMTPPass       string // SMTP_PASS (solo servidor; nunca en logs ni BD)
-	SMTPFrom       string // SMTP_FROM ("EasyZFS <easyzfs@example.com>")
-	SMTPEncryption string // SMTP_ENCRYPTION: none | starttls | tls (def starttls)
+	SMTPHost       string        // SMTP_HOST
+	SMTPPort       int           // SMTP_PORT (def 587)
+	SMTPUser       string        // SMTP_USER (vacío = SMTP sin autenticación)
+	SMTPPass       string        // SMTP_PASS (solo servidor; nunca en logs ni BD)
+	SMTPFrom       string        // SMTP_FROM ("EasyZFS <easyzfs@example.com>")
+	SMTPEncryption string        // SMTP_ENCRYPTION: none | starttls | tls (def starttls)
 	SMTPTimeout    time.Duration // SMTP_TIMEOUT (def 10s)
-	SMTPTestTo     string // SMTP_TEST_TO: fuerza destino de prueba en todos los envíos
+	SMTPTestTo     string        // SMTP_TEST_TO: fuerza destino de prueba en todos los envíos
+
+	// Canales de alerta adicionales (#86). Vacio = canal desactivado.
+	NtfyURL        string // NTFY_URL (p.ej. https://ntfy.sh/mi-topic)
+	NtfyToken      string // NTFY_TOKEN (opcional; vacío = sin auth)
+	GotifyURL      string // GOTIFY_URL (p.ej. https://gotify.example.com)
+	GotifyToken    string // GOTIFY_TOKEN (app token de Gotify)
+	SyslogHost     string // SYSLOG_HOST (p.ej. 127.0.0.1)
+	SyslogPort     int    // SYSLOG_PORT (def 514)
+	SyslogProto    string // SYSLOG_PROTO: udp | tcp (def udp)
+	SyslogFacility int    // SYSLOG_FACILITY (def 1 = user)
 }
 
 // DataDir — directorio de datos del daemon (deriva de DB_PATH): ahí viven la
@@ -82,6 +92,15 @@ func Load() *Config {
 		SMTPEncryption: env("SMTP_ENCRYPTION", "starttls"),
 		SMTPTimeout:    time.Duration(envInt("SMTP_TIMEOUT", 10)) * time.Second,
 		SMTPTestTo:     os.Getenv("SMTP_TEST_TO"),
+
+		NtfyURL:        os.Getenv("NTFY_URL"),
+		NtfyToken:      os.Getenv("NTFY_TOKEN"),
+		GotifyURL:      os.Getenv("GOTIFY_URL"),
+		GotifyToken:    os.Getenv("GOTIFY_TOKEN"),
+		SyslogHost:     os.Getenv("SYSLOG_HOST"),
+		SyslogPort:     envInt("SYSLOG_PORT", 514),
+		SyslogProto:    env("SYSLOG_PROTO", "udp"),
+		SyslogFacility: envInt("SYSLOG_FACILITY", 1),
 	}
 	if cfg.Demo {
 		cfg.Mock = true // demo implica colectores mock

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"easyzfs/internal/alerts"
 	"easyzfs/internal/auth"
 	"easyzfs/internal/backup"
+	"easyzfs/internal/channels"
 	"easyzfs/internal/collectors"
 	"easyzfs/internal/config"
 	"easyzfs/internal/db"
@@ -125,6 +126,18 @@ func main() {
 	// Ticker de la cola de quiet hours (60 s): entrega diferida al terminar
 	// la ventana de silencio. En demo o sin VAPID queda inerte.
 	go pushSender.RunQueue(ctx)
+
+	// Canales ntfy/gotify/syslog (#86): inerte si no hay ninguna configurada.
+	channelsClient := channels.New(
+		cfg.NtfyURL, cfg.NtfyToken,
+		cfg.GotifyURL, cfg.GotifyToken,
+		cfg.SyslogHost, cfg.SyslogPort, cfg.SyslogProto, cfg.SyslogFacility,
+	)
+	if channelsClient.Enabled() {
+		alerter.SetChannels(channelsClient)
+		log.Printf("canales de alerta configurados (ntfy=%v gotify=%v syslog=%v)",
+			cfg.NtfyURL != "", cfg.GotifyURL != "", cfg.SyslogHost != "")
+	}
 
 	// Colectores (reales o mock) + providers para los handlers.
 	providers, cols := collectors.Build(cfg, database, h, alerter)


### PR DESCRIPTION
Closes #86

## What

New `internal/channels` package delivering alerts to three additional channels, all optional (inert unless configured via env, same pattern as SMTP):

- **ntfy**: POST JSON to `NTFY_URL` with optional `NTFY_TOKEN` (Bearer)
- **Gotify**: POST to `GOTIFY_URL/message` with `X-Gotify-Key` (app token)
- **Syslog**: RFC 3164 datagrams over UDP/TCP (`SYSLOG_HOST`, `SYSLOG_PORT`, `SYSLOG_PROTO`, `SYSLOG_FACILITY`)

Each alert (kind) is sent best-effort async with a 30s timeout, composed via the existing push i18n catalog in Spanish by default; failures are logged and never break the alert path. Main wiring logs which channels are active at startup.

## Tests

- channels: ntfy payload+auth, gotify payload+key, syslog UDP datagram with PRI, disabled client no-op, failure no-panic.
- alerts: integration test RaiseKind delivers to ntfy.
- Full Go suite green.