### PR TITLE
Toast notifications for action feedback + confirm fix for destructive actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import type { ComponentType } from 'react';
 import { AppProvider, useApp, alertTargetView } from './ui/store';
 import type { ViewId } from './ui/store';
 import { ModalProvider, ModalHost } from './components/ModalHost';
+import { ToastHost } from './components/Toast';
 import { Logo, IconHome, IconPool, IconData, IconSnap, IconTask, IconDisk, IconGear, IconBell, IconMoon, IconSun, IconMonitor, IconChev, IconFoldLeft, IconFoldRight, IconUser, IconList } from './components/icons';
 import { Spinner } from './components/ui';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -362,6 +363,7 @@ function Shell() {
       </nav>
 
       <ModalHost />
+      <ToastHost />
     </>
   );
 }

--- a/web/src/components/Modals.tsx
+++ b/web/src/components/Modals.tsx
@@ -93,7 +93,7 @@ export function ModalHost() {
 
 // ---------- crear snapshot ----------
 function SnapshotModal({ preset, onClose }: { preset?: string; onClose: () => void }) {
-  const { t, refresh } = useApp();
+  const { t, refresh, notify } = useApp();
   const datasets = useLoad(() => getProvider().getDatasets());
   const pools = useLoad(() => getProvider().getPools());
   const [target, setTarget] = useState(preset ?? '');
@@ -113,7 +113,8 @@ function SnapshotModal({ preset, onClose }: { preset?: string; onClose: () => vo
     try {
       await getProvider().createSnapshot({ dataset: target, name, recursive: isPoolTarget });
       refresh(); onClose();
-    } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
+      notify(t('toast_snap_created'), 'ok');
+    } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
   };
 
   return (
@@ -327,7 +328,7 @@ function NewPoolModal({ onClose }: { onClose: () => void }) {
 
 // ---------- nuevo dataset / zvol ----------
 function NewDatasetModal({ vol, onClose }: { vol: boolean; onClose: () => void }) {
-  const { t, refresh } = useApp();
+  const { t, refresh, notify } = useApp();
   const pools = useLoad(() => getProvider().getPools());
   const [pool, setPool] = useState('');
   const [name, setName] = useState('');
@@ -353,7 +354,8 @@ function NewDatasetModal({ vol, onClose }: { vol: boolean; onClose: () => void }
         encryption: enc || undefined, passphrase: enc ? pass1 : undefined,
       });
       refresh(); onClose();
-    } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
+      notify(t('toast_ds_created'), 'ok');
+    } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
   };
 
   return (
@@ -763,7 +765,7 @@ function DiskDetailModal({ disk, onClose }: { disk: Disk; onClose: () => void })
 
 // ---------- eliminar dataset (confirmación escrita) ----------
 function DeleteDatasetModal({ name, onClose }: { name: string; onClose: () => void }) {
-  const { t, refresh, isAdmin } = useApp();
+  const { t, refresh, isAdmin, notify } = useApp();
   const [confirm, setConfirm] = useState('');
   const [recursive, setRecursive] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -775,7 +777,8 @@ function DeleteDatasetModal({ name, onClose }: { name: string; onClose: () => vo
     try {
       await getProvider().deleteDataset(name, confirm.trim(), recursive);
       refresh(); onClose();
-    } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
+      notify(t('toast_ds_deleted'), 'ok');
+    } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
   };
 
   return (
@@ -1391,7 +1394,7 @@ function DetachModal({ pool, dev, path, onClose }: { pool: string; dev: string; 
 
 // ---------- rollback de snapshot ----------
 function RollbackModal({ full, onClose }: { full: string; onClose: () => void }) {
-  const { t, refresh, isAdmin } = useApp();
+  const { t, refresh, isAdmin, notify } = useApp();
   const [confirm, setConfirm] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
@@ -1403,7 +1406,8 @@ function RollbackModal({ full, onClose }: { full: string; onClose: () => void })
     try {
       await getProvider().rollback(full, confirm.trim());
       refresh(); onClose();
-    } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
+      notify(t('toast_rollback'), 'ok');
+    } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
   };
 
   return (
@@ -1426,7 +1430,7 @@ function RollbackModal({ full, onClose }: { full: string; onClose: () => void })
 
 // ---------- eliminar snapshot ----------
 function DeleteSnapModal({ full, onClose }: { full: string; onClose: () => void }) {
-  const { t, refresh, isAdmin } = useApp();
+  const { t, refresh, isAdmin, notify } = useApp();
   const [confirm, setConfirm] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
@@ -1438,7 +1442,8 @@ function DeleteSnapModal({ full, onClose }: { full: string; onClose: () => void 
     try {
       await getProvider().deleteSnapshot(full, confirm.trim());
       refresh(); onClose();
-    } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
+      notify(t('toast_snap_deleted'), 'ok');
+    } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
   };
 
   return (

--- a/web/src/components/Modals.tsx
+++ b/web/src/components/Modals.tsx
@@ -1404,7 +1404,8 @@ function RollbackModal({ full, onClose }: { full: string; onClose: () => void })
     e.preventDefault();
     setBusy(true); setErr('');
     try {
-      await getProvider().rollback(full, confirm.trim());
+      // El backend exige confirm == ruta completa; la UI pide el dataset
+      await getProvider().rollback(full, confirm.trim() === ds ? full : confirm.trim());
       refresh(); onClose();
       notify(t('toast_rollback'), 'ok');
     } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
@@ -1440,7 +1441,8 @@ function DeleteSnapModal({ full, onClose }: { full: string; onClose: () => void 
     e.preventDefault();
     setBusy(true); setErr('');
     try {
-      await getProvider().deleteSnapshot(full, confirm.trim());
+      // El backend exige confirm == ruta completa; la UI pide el nombre corto
+      await getProvider().deleteSnapshot(full, confirm.trim() === snap ? full : confirm.trim());
       refresh(); onClose();
       notify(t('toast_snap_deleted'), 'ok');
     } catch (ex) { const msg = errorMessage(ex, t); setErr(msg); notify(msg, 'err'); setBusy(false); }
@@ -1643,7 +1645,8 @@ function EditScheduleModal({ job, onClose }: { job: Job; onClose: () => void }) 
   const remove = async () => {
     setBusy(true); setErr('');
     try {
-      await getProvider().deleteJob(job.id, String(job.id));
+      // El backend exige confirm == target del job (no su id)
+      await getProvider().deleteJob(job.id, job.target);
       refresh(); onClose();
     } catch (ex) { setErr(errorMessage(ex, t)); setBusy(false); }
   };

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,0 +1,28 @@
+// Host de toasts ligeros (sistema propio, sin dependencias). Cola global de
+// AppCtx (store.tsx): notify() encola, dismissToast() descarta. Aparecen
+// abajo-derecha, por encima de los modales, con aria-live para lectores de
+// pantalla. Port refactorizado del fork coruhoorhan/easyzfs-truenas (AGPL-3.0).
+import { useApp } from '../ui/store';
+import type { Toast, ToastKind } from '../ui/store';
+
+const KIND_CLASS: Record<ToastKind, string> = {
+  ok: 'ok',
+  err: 'err',
+  warn: 'warn',
+  info: 'info',
+};
+
+export function ToastHost() {
+  const { toasts, dismissToast, t } = useApp();
+  if (toasts.length === 0) return null;
+  return (
+    <div className="toast-host" role="region" aria-live="polite" aria-label={t('toast_dismiss')}>
+      {toasts.map((tst: Toast) => (
+        <div key={tst.id} className={`toast ${KIND_CLASS[tst.kind]}`} role={tst.kind === 'err' ? 'alert' : 'status'}>
+          <span className="toast-msg">{tst.msg}</span>
+          <button type="button" className="toast-x" aria-label={t('toast_dismiss')} onClick={() => dismissToast(tst.id)}>×</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/data/mock.ts
+++ b/web/src/data/mock.ts
@@ -791,7 +791,7 @@ export class MockProvider implements DataProvider {
   rollback = async (full: string, confirm: string) => {
     await delay(300);
     const [ds] = full.split('@');
-    if (confirm !== ds) throw new ApiError(400, 'confirm_required', `Escribe "${ds}" para confirmar`);
+    if (confirm !== ds && confirm !== full) throw new ApiError(400, 'confirm_required', `Escribe "${ds}" para confirmar`);
     this.activity.unshift({ ts: iso(new Date()), text: 'Rollback ejecutado', detail: full });
   };
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -544,6 +544,7 @@ table.data td.num{font-family:var(--font-mono);font-size:12.5px}
  *   40 — bottomnav (navegación inferior móvil)
  *   50 — popovers/dropdowns (sel-pop, alertpanel) y tooltips (infobubble-pop)
  *   60 — overlay + modal (SIEMPRE por encima de cualquier popover/tooltip)
+ *   70 — toasts (avisos de acciones, visibles incluso sobre un modal)
  * Regla: nada que viva dentro de una tarjeta/vista puede superar 60. */
 /* modal */
 .overlay{
@@ -871,3 +872,27 @@ html.reduce-motion *{transition:none!important;animation:none!important}
   .tr-ranges { justify-content: space-between; }
   .tr-range { flex: 1; text-align: center; padding: 8px 4px; }
 }
+
+/* toasts — avisos de acciones (70: por encima del modal), abajo-derecha */
+.toast-host{
+  position:fixed;right:14px;bottom:calc(12px + env(safe-area-inset-bottom));
+  z-index:70;display:flex;flex-direction:column;gap:8px;max-width:min(360px,92vw);
+  pointer-events:none;
+}
+.toast{
+  pointer-events:auto;display:flex;align-items:flex-start;gap:10px;
+  background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--accent);
+  border-radius:10px;padding:11px 12px;box-shadow:0 6px 22px rgba(10,14,10,.22);
+  color:var(--text);font-size:13.5px;line-height:1.45;
+  animation:toast-in .18s ease-out;
+}
+.toast.err{border-left-color:var(--err)}
+.toast.warn{border-left-color:var(--warn)}
+.toast.ok{border-left-color:var(--ok)}
+.toast .toast-msg{flex:1;word-break:break-word}
+.toast .toast-x{
+  flex-shrink:0;background:transparent;border:0;color:var(--text2);font-size:16px;
+  line-height:1;padding:2px 4px;cursor:pointer;border-radius:6px;
+}
+.toast .toast-x:hover{color:var(--text);background:var(--surface2)}
+@keyframes toast-in{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -560,6 +560,12 @@ const es = {
   // Accesibilidad
   a11y_close_modal: 'Cerrar ventana', a11y_theme: 'Cambiar tema', a11y_alerts: 'Alertas',
   a11y_mainnav: 'Navegación principal',
+
+  // Toasts (avisos de acciones)
+  toast_dismiss: 'Descartar aviso',
+  toast_snap_created: 'Snapshot creado', toast_snap_deleted: 'Snapshot eliminado',
+  toast_rollback: 'Rollback en curso', toast_ds_created: 'Dataset creado',
+  toast_ds_deleted: 'Dataset eliminado',
 };
 
 export type I18nKey = keyof typeof es;
@@ -1104,6 +1110,11 @@ const en: Record<I18nKey, string> = {
 
   a11y_close_modal: 'Close dialog', a11y_theme: 'Toggle theme', a11y_alerts: 'Alerts',
   a11y_mainnav: 'Main navigation',
+
+  toast_dismiss: 'Dismiss',
+  toast_snap_created: 'Snapshot created', toast_snap_deleted: 'Snapshot deleted',
+  toast_rollback: 'Rollback started', toast_ds_created: 'Dataset created',
+  toast_ds_deleted: 'Dataset deleted',
 };
 
 const DICTS: Record<'es' | 'en', Record<I18nKey, string>> = { es, en };

--- a/web/src/ui/store.tsx
+++ b/web/src/ui/store.tsx
@@ -21,6 +21,13 @@ function parseHash(): ViewId {
   return VIEWS.includes(h) ? h : 'dash';
 }
 
+// --- Toasts (avisos ligeros de acciones) ---------------------------
+// Port refactorizado del fork comunitario coruhoorhan/easyzfs-truenas (AGPL-3.0).
+export type ToastKind = 'ok' | 'err' | 'warn' | 'info';
+export interface Toast { id: number; msg: string; kind: ToastKind }
+let nextToastId = 1;
+const MAX_TOASTS = 4;
+
 interface AppCtx {
   ready: boolean;            // provider inicializado
   demo: boolean;
@@ -48,6 +55,10 @@ interface AppCtx {
   dataVersion: number;
   // Re-lee /api/me (tras guardar perfil: nombre visible, email…)
   reloadUser: () => void;
+  // Toasts: notify() encola (auto-cierre solo), dismissToast() descarta
+  toasts: Toast[];
+  notify: (msg: string, kind?: ToastKind) => void;
+  dismissToast: (id: number) => void;
 }
 
 const Ctx = createContext<AppCtx | null>(null);
@@ -226,13 +237,26 @@ export function AppProvider({ children }: { children: ReactNode }) {
     getProvider().me().then(setUser).catch(() => {});
   }, []);
 
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  // Encola un aviso; se cierra solo (los errores duran más). Si la cola se
+  // llena, se descartan los más antiguos.
+  const notify = useCallback((msg: string, kind: ToastKind = 'info') => {
+    const id = nextToastId++;
+    setToasts((cur) => [...cur, { id, msg, kind }].slice(-MAX_TOASTS));
+    setTimeout(() => setToasts((cur) => cur.filter((x) => x.id !== id)), kind === 'err' ? 6000 : 3500);
+  }, []);
+  const dismissToast = useCallback((id: number) => {
+    setToasts((cur) => cur.filter((x) => x.id !== id));
+  }, []);
+
   const value = useMemo<AppCtx>(() => ({
     ready, demo, user, route, navigate, login, login2FA, logout, enterDemo, exitDemo,
     t, langMode, setLang, themeMode, themeEff, setTheme,
     isAdmin: user?.role === 'admin',
     caps,
     refresh, dataVersion, reloadUser,
-  }), [ready, demo, user, route, navigate, login, login2FA, logout, enterDemo, exitDemo, t, langMode, setLang, themeMode, themeEff, setTheme, caps, refresh, dataVersion, reloadUser]);
+    toasts, notify, dismissToast,
+  }), [ready, demo, user, route, navigate, login, login2FA, logout, enterDemo, exitDemo, t, langMode, setLang, themeMode, themeEff, setTheme, caps, refresh, dataVersion, reloadUser, toasts, notify, dismissToast]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }


### PR DESCRIPTION
## What

**Toast notifications (#94)**: a small dependency-free toast system so mutating actions give visible feedback. A global queue lives in the app store (`notify` / `dismissToast`), ToastHost renders bottom-right above modals (z-index 70), aria-live polite with role=alert on errors, auto-dismiss after 3.5s (6s for errors), queue capped at 4, reduce-motion respected. Wired into snapshot create/delete, rollback, and dataset create/delete: success toast on completion, error toast mirroring the modal error.

Ported from the community fork coruhoorhan/easyzfs-truenas (AGPL-3.0) and refactored against current main. Credit to coruhoorhan.

**Confirm fix (#95)**: found while porting. Delete snapshot, rollback, and task delete never passed the backend confirm gate against a real backend: the UI sent the short name (or dataset name, or job id) while the backend requires confirm to equal the full snapshot path (or the job target). All three always failed with 400 confirm_required; the demo mock accepted the short values, which hid the bug. The UI now maps the typed value to the one the backend expects. The fork had the delete case; rollback and task delete are fixed the same way. Demo mock rollback updated to accept the full path too.

## Verification

- Playwright against demo mode: 11/11 local and 11/11 against the public demo over HTTPS (toasts on the 5 actions, auto-dismiss, aria-live, z-index, mobile overflow, 0 pageerrors).
- Against a real (non-demo, MOCK=1) backend: bug reproduced first (400 confirm_required), then 5/5 after the fix (confirm gate passed on delete and rollback, task delete returns 204).
- `go test ./...` green, frontend build clean.

Closes #94
Closes #95