### PR TITLE
docs(readme): add live demo link and callout

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -14,6 +14,8 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Apóyame en Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
+<p align="center"><a href="https://demo.easyzfs.cloudless.club"><strong>Prueba la demo en vivo</strong></a> en <code>demo.easyzfs.cloudless.club</code></p>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/hero-es-dark.png">

--- a/README.es.md
+++ b/README.es.md
@@ -31,6 +31,10 @@ embebida. Corre 24/7 con una huella mínima y se despliega en un LXC Debian
 + systemd. Sin Docker, sin sistema operativo de appliance, sin stack
 pesado.
 
+> **Prueba la demo en vivo**
+>
+> Mírala en funcionamiento sin instalar nada. Entra en **[demo.easyzfs.cloudless.club](https://demo.easyzfs.cloudless.club)** — dos pools de ejemplo con datos mock realistas, sin registro. En modo demo las acciones destructivas están bloqueadas, así que puedes explorar sin riesgo.
+
 ## ¿Por qué existe?
 
 Tras años con NAS comerciales (primero Synology, luego QNAP) acabé con

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="https://ko-fi.com/gnacho"><img alt="Support on Ko-fi" src="https://img.shields.io/badge/Ko--fi-Donate-ff5e5b?logo=ko-fi&logoColor=white"></a>
 </p>
 
+<p align="center"><a href="https://demo.easyzfs.cloudless.club"><strong>Try the live demo</strong></a> on <code>demo.easyzfs.cloudless.club</code></p>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/hero-en-dark.png">

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ hwmon sensors), exposes a REST + SSE API and serves an embedded PWA. It runs
 24/7 with a minimal footprint and deploys on a Debian LXC + systemd. No
 Docker, no appliance OS, no heavy stack.
 
+> **Try the live demo**
+>
+> See it running without installing anything. Head to **[demo.easyzfs.cloudless.club](https://demo.easyzfs.cloudless.club)** — two sample ZFS pools, realistic mock data, no sign-up required. In demo mode destructive actions are blocked, so you can explore freely.
+
 ## Why does this exist?
 
 After years with commercial NAS boxes (first Synology, then QNAP), I ended


### PR DESCRIPTION
Adds a clear live demo link (in prose, next to the badges) and a visible demo callout after the intro paragraph, in both the English and Spanish README.

Documentation only.