### PR TITLE
fix(landing): add Umami analytics tracker

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -567,5 +567,6 @@
 
   <script src="i18n.js?v=8"></script>
   <script src="app.js?v=6"></script>
+<script defer src="https://stat.domatix.com/script.js" data-website-id="e8687a82-cc8a-50cb-80ba-f83d9ce8353a"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the stat.domatix.com tracker to the landing page so visits are recorded in Umami.\n\nCloses #120