### PR TITLE
chore(ci): build the web UI with Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
Bumps the CI runtime used to build the embedded web UI from Node 22 to Node 24, aligning EasyZFS with the rest of the stack (NetPulse/NetGrip already use 24). Go backend is unaffected (Node is build-time only).

Changes:
- `ci.yml` + `release.yml`: setup-node `node-version` 22 -> 24

Verified locally under Node 24.18.1: `tsc --noEmit` clean, web build OK.