### PR TITLE
chore(ci): align go-version declaration with go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       # go:embed dist lo exige presente; dist/ no se trackea (ver .gitignore).
       # Los tests de backend no tocan la SPA, un placeholder basta para compilar.
       - name: Prepara dist/ para go:embed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Aligns the declared `go-version` in `ci.yml` (backend job) and `release.yml` with the module's `go.mod` directive (`go 1.25.12`). The backend and release jobs were pinned to `1.24`, below the module minimum; Go's toolchain auto-switching made it still work, but the declaration was out of sync. Bumping to `1.25` matches `staticcheck` and the module requirement.

Changes:
- `ci.yml`: backend `go-version` 1.24 -> 1.25
- `release.yml`: `go-version` 1.24 -> 1.25