### PR TITLE
feat(ui): port full mockup redesign (capa3 structure)

### DIFF
--- a/internal/httpapi/system.go
+++ b/internal/httpapi/system.go
@@ -4,8 +4,10 @@ package httpapi
 import (
 	"context"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"easyzfs/internal/db"
@@ -35,21 +37,109 @@ func (s *Server) getVersion(w http.ResponseWriter, r *http.Request) {
 			caps = c
 		}
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"name":         "EasyZFS",
-		"version":      s.version,
-		"build":        s.build,
-		"go":           runtime.Version(),
-		"os_arch":      runtime.GOOS + "/" + runtime.GOARCH,
-		"uptime_sec":   int64(time.Since(s.started).Seconds()),
-		"rss_bytes":    memRSS(),
-		"db_bytes":     db.SizeBytes(s.cfg.DBPath),
-		"db_path":      s.cfg.DBPath,
-		"zfs_version":  caps.Version,
-		"capabilities": caps,
-		"demo":         s.cfg.Demo,
+	out := map[string]any{
+		"name":          "EasyZFS",
+		"version":       s.version,
+		"build":         s.build,
+		"go":            runtime.Version(),
+		"os_arch":       runtime.GOOS + "/" + runtime.GOARCH,
+		"uptime_sec":    int64(time.Since(s.started).Seconds()),
+		"rss_bytes":     memRSS(),
+		"db_bytes":      db.SizeBytes(s.cfg.DBPath),
+		"db_path":       s.cfg.DBPath,
+		"zfs_version":   caps.Version,
+		"capabilities":  caps,
+		"demo":          s.cfg.Demo,
 		"pendingUpdate": pendingUpdateJSON(s.updater),
-	})
+	}
+	// Métricas del host (best effort: se omiten si no se pueden leer).
+	if l1, l5, l15, ok := loadAvg(); ok {
+		out["load1"], out["load5"], out["load15"] = l1, l5, l15
+	}
+	if total, avail, ok := memInfo(); ok {
+		out["mem_total_bytes"], out["mem_avail_bytes"] = total, avail
+	}
+	if hit, size, ok := arcStats(); ok {
+		out["arc_hit_pct"], out["arc_size_bytes"] = hit, size
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// loadAvg lee /proc/loadavg (load 1/5/15).
+func loadAvg() (l1, l5, l15 float64, ok bool) {
+	b, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	f := strings.Fields(string(b))
+	if len(f) < 3 {
+		return 0, 0, 0, false
+	}
+	l1, err1 := strconv.ParseFloat(f[0], 64)
+	l5, err5 := strconv.ParseFloat(f[1], 64)
+	l15, err15 := strconv.ParseFloat(f[2], 64)
+	if err1 != nil || err5 != nil || err15 != nil {
+		return 0, 0, 0, false
+	}
+	return l1, l5, l15, true
+}
+
+// memInfo lee MemTotal/MemAvailable de /proc/meminfo (en bytes).
+func memInfo() (total, avail uint64, ok bool) {
+	b, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0, 0, false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 2 {
+			continue
+		}
+		kb, err := strconv.ParseUint(f[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch strings.TrimSuffix(f[0], ":") {
+		case "MemTotal":
+			total = kb * 1024
+		case "MemAvailable":
+			avail = kb * 1024
+		}
+	}
+	return total, avail, total > 0
+}
+
+// arcStats calcula el hit ratio del ARC de ZFS a partir de
+// /proc/spl/kstat/zfs/arcstats (hits/(hits+misses)). Devuelve también el
+// tamaño actual del ARC en bytes.
+func arcStats() (hitPct float64, sizeBytes uint64, ok bool) {
+	b, err := os.ReadFile("/proc/spl/kstat/zfs/arcstats")
+	if err != nil {
+		return 0, 0, false
+	}
+	var hits, misses, size uint64
+	for _, line := range strings.Split(string(b), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
+			continue
+		}
+		v, err := strconv.ParseUint(f[2], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch f[0] {
+		case "hits":
+			hits = v
+		case "misses":
+			misses = v
+		case "size":
+			size = v
+		}
+	}
+	if hits+misses == 0 {
+		return 0, size, false
+	}
+	return float64(hits) / float64(hits+misses) * 100, size, true
 }
 
 // getSettings — GET /api/settings.
@@ -133,17 +223,17 @@ func validateSettings(st settingsBody) string {
 
 // settingsBody — body de PUT /api/settings (idéntico a settings.Settings).
 type settingsBody struct {
-	Lang              string `json:"lang"`
-	CapWarnPct        int    `json:"cap_warn_pct"`
-	CapCritPct        int    `json:"cap_crit_pct"`
-	DiskTempC         int    `json:"disk_temp_c"`
-	Webhook           string `json:"webhook"`
-	NotifyScrubErrors bool   `json:"notify_scrub_errors"`
-	NotifySmartChange bool   `json:"notify_smart_change"`
-	DemoEnabled       bool   `json:"demo_enabled"`
-	BackupEnabled       bool `json:"backup_enabled"`
-	BackupFreqHours     int  `json:"backup_freq_hours"`
-	BackupRetentionDays int  `json:"backup_retention_days"`
+	Lang                string `json:"lang"`
+	CapWarnPct          int    `json:"cap_warn_pct"`
+	CapCritPct          int    `json:"cap_crit_pct"`
+	DiskTempC           int    `json:"disk_temp_c"`
+	Webhook             string `json:"webhook"`
+	NotifyScrubErrors   bool   `json:"notify_scrub_errors"`
+	NotifySmartChange   bool   `json:"notify_smart_change"`
+	DemoEnabled         bool   `json:"demo_enabled"`
+	BackupEnabled       bool   `json:"backup_enabled"`
+	BackupFreqHours     int    `json:"backup_freq_hours"`
+	BackupRetentionDays int    `json:"backup_retention_days"`
 }
 
 // listAlerts — GET /api/alerts → últimas 100.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,8 @@ import ErrorBoundary from './components/ErrorBoundary';
 import PullToRefresh from './components/PullToRefresh';
 import { getProvider } from './data';
 import { subscribeEvents } from './data/events';
+import { fmtBytes, fmtBytesPair, fmtDuration } from './ui/format';
+import type { VersionInfo } from './data/types';
 import { timeAgo } from './ui/format';
 import { lazyRetry } from './ui/lazyRetry';
 import { useUpdateAvailable } from './ui/updatecheck';
@@ -115,6 +117,73 @@ function AlertsPanel({ onClose }: { onClose: () => void }) {
         })}
       </div>
     </div>
+  );
+}
+
+// Panel de métricas del host en el sidebar (uptime, load, RAM daemon/sistema,
+// ARC hit). Los campos son best-effort: una fila solo se pinta si el server
+// la reporta (/api/version). Se refresca cada 30 s.
+function SideStats() {
+  const [v, setV] = useState<VersionInfo | null>(null);
+  useEffect(() => {
+    let alive = true;
+    const load = () => getProvider().getVersion().then((x) => alive && setV(x)).catch(() => {});
+    load();
+    const id = setInterval(load, 30000);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+  if (!v) return null;
+  const memUsed = v.mem_total_bytes && v.mem_avail_bytes != null
+    ? v.mem_total_bytes - v.mem_avail_bytes : null;
+  const memPct = memUsed != null && v.mem_total_bytes
+    ? Math.round((memUsed / v.mem_total_bytes) * 100) : null;
+  return (
+    <div className="side-stats">
+      <div className="ss-row">
+        <span className="ss-k">UPTIME</span>
+        <span className="ss-v g">{fmtDuration(v.uptime_sec)}</span>
+      </div>
+      {v.load1 != null && (
+        <div className="ss-row">
+          <span className="ss-k">LOAD</span>
+          <span className="ss-v">{v.load1.toFixed(2)} {v.load5?.toFixed(2)} {v.load15?.toFixed(2)}</span>
+        </div>
+      )}
+      <div className="ss-row">
+        <span className="ss-k">RAM · daemon</span>
+        <span className="ss-v">{fmtBytes(v.rss_bytes)}</span>
+      </div>
+      {memUsed != null && v.mem_total_bytes != null && (
+        <div className="ss-row ss-col">
+          <div className="ss-line">
+            <span className="ss-k">RAM · system</span>
+            <span className="ss-v">{(() => { const p = fmtBytesPair(memUsed, v.mem_total_bytes); return `${p.used} / ${p.total}`; })()}</span>
+          </div>
+          {memPct != null && <div className="minibar"><i style={{ width: `${memPct}%` }} /></div>}
+        </div>
+      )}
+      {v.arc_hit_pct != null && (
+        <div className="ss-row">
+          <span className="ss-k">ARC HIT</span>
+          <span className="ss-v g">{v.arc_hit_pct.toFixed(1)}%</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Reloj de consola en la topbar (mono, tabular; oculto < 1100px por CSS).
+function Clock() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const p = (n: number) => String(n).padStart(2, '0');
+  return (
+    <span className="clock" aria-hidden="true">
+      {p(now.getHours())}:{p(now.getMinutes())}<b>:{p(now.getSeconds())}</b>
+    </span>
   );
 }
 
@@ -223,6 +292,7 @@ function Shell() {
               );
             })}
           </nav>
+          {!collapsed && <SideStats />}
           <div className="sidefoot">
             <div className="sideactions">
               <a href="#/settings" className={active === 'settings' ? 'active' : ''}
@@ -296,6 +366,8 @@ function Shell() {
               </div>
             </div>
             <div className="head-actions">
+              <span className="live-badge"><span className="live-dot" />LIVE</span>
+              <Clock />
               <button className="iconbtn" title={t('a11y_alerts')} aria-label={t('a11y_alerts')}
                 style={{ position: 'relative' }} onClick={() => { setShowAlerts((v) => !v); setHasPending(false); }}>
                 <IconBell />

--- a/web/src/components/PoolCard.tsx
+++ b/web/src/components/PoolCard.tsx
@@ -5,7 +5,7 @@ import { errorMessage, useApp } from '../ui/store';
 import { t } from '../ui/i18n';
 import { fmtBytes, fmtBytesPair, fmtPct, fmtRatio, timeAgo } from '../ui/format';
 import { statusLabel } from '../ui/labels';
-import { Badge, InfoBubble, Meter, Switch } from './ui';
+import { Badge, InfoBubble, Switch } from './ui';
 import { Sparkline } from './Sparkline';
 import { useModal } from './Modal';
 import { useEffect, useState } from 'react';
@@ -117,38 +117,43 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
   const canExpand = isAdmin && !!caps?.raidz_expansion &&
     (pool.raidz_vdevs ?? []).length > 0 && free.length > 0 && !expanding;
 
+  const ledCls = ok ? 'g' : pool.status === 'DEGRADED' ? 'a' : 'r';
   return (
     <div className="card">
-      <div className="poolhead">
+      <div className="pool-head">
+        <span className={`led ${ledCls}`} />
         <div className="grow">
-          <div className="t1" style={{ fontSize: 16, fontWeight: 700, display: 'flex', gap: 9, alignItems: 'center' }}>
+          <div className="pool-name">
             {pool.name} <Badge tone={ok ? 'ok' : 'warn'}>{statusLabel(pool.status, t)}</Badge>
             {pool.checkpoint && <Badge tone="info">{t('ck_badge')}</Badge>}
           </div>
-          <div className="t2">{pool.topo}</div>
-          <TopoHelp topo={pool.topo} />
-          <Meter pct={pct} />
-          {hist.length > 0 && (
-            <div className="sparks" aria-label={t('pool_history_series')}>
-              {hist.sort((a, b) => a.days - b.days).map((h) => (
-                <span key={h.days} className="spark" title={t('pool_history_days', { days: h.days })}>
-                  <Sparkline points={h.points} width={72} height={26}
-                    ariaLabel={t('pool_history_days', { days: h.days })} />
-                  <em>{h.days}d</em>
-                </span>
-              ))}
-            </div>
-          )}
+          <div className="pool-raid">{pool.topo} <TopoHelp topo={pool.topo} /></div>
         </div>
-        <div style={{ textAlign: 'right' }}>
-          <div style={{ fontWeight: 700, fontSize: 17 }}>
+        <div className="pool-cap">
+          <div className="big">
             {cap.used}
-            <span className="muted" style={{ fontWeight: 500 }}>
-              {' '}{t('pool_of')} {cap.total}
-            </span>
+            <span className="dim">{' '}{t('pool_of')} {cap.total}</span>
           </div>
-          <div style={{ fontSize: 12, color: 'var(--text2)' }}>{fmtPct(pct)} {t('pool_used')}</div>
+          <div className="pct">{fmtPct(pct)} {t('pool_used')}</div>
         </div>
+      </div>
+
+      <div className="pool-bar">
+        <div className={`segbar ${pct >= 90 ? 'crit' : pct >= 80 ? 'warn' : ''}`}
+          role="progressbar" aria-valuenow={Math.round(pct)} aria-valuemin={0} aria-valuemax={100}>
+          <i style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
+        </div>
+        {hist.length > 0 && (
+          <div className="sparks" aria-label={t('pool_history_series')}>
+            {hist.sort((a, b) => a.days - b.days).map((h) => (
+              <span key={h.days} className="spark" title={t('pool_history_days', { days: h.days })}>
+                <Sparkline points={h.points} width={72} height={26}
+                  ariaLabel={t('pool_history_days', { days: h.days })} />
+                <em>{h.days}d</em>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="poolmeta">
@@ -205,22 +210,24 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
           // que desaparece solo al terminar la reconstrucción.
           if (v.replacing && v.status !== 'ONLINE') {
             return (
-              <div className="vdev" key={v.dev} style={{ opacity: 0.55 }}>
+              <div className="vdev out" key={v.dev}>
+                <span className="led o" />
                 <span className="badge info" style={{ padding: '2px 7px' }}>{t('vdev_outgoing')}</span>
                 <span className="dname" title={v.dev}>{shortDev(v)}</span>
-                <span style={{ fontSize: 12, color: 'var(--text2)' }}>{t('vdev_outgoing_hint')}</span>
+                <span className="drole">{t('vdev_outgoing_hint')}</span>
               </div>
             );
           }
           return (
-          <div className="vdev" key={v.dev} style={v.replacing ? { flexWrap: 'wrap' } : undefined}>
+          <div className={`vdev${v.status !== 'ONLINE' ? ' faulted' : ''}`} key={v.dev} style={v.replacing ? { flexWrap: 'wrap' } : undefined}>
+            <span className={`led ${v.status === 'ONLINE' ? 'g' : v.status === 'OFFLINE' ? 'o' : 'r'}`} />
             <span className={`badge ${v.status === 'ONLINE' ? 'ok' : 'err'}`} style={{ padding: '2px 7px' }}>{statusLabel(v.status, t)}</span>
             <span className="dname" title={v.dev}>{shortDev(v)}</span>
             {v.replacing && (
               <span className="badge info" style={{ padding: '1px 7px' }} title={t('vdev_new_hint')}>{t('vdev_new')}</span>
             )}
-            <span>{v.role !== '—' ? v.role : ''}</span>
-            <span style={{ marginLeft: 'auto' }}>{v.temp_c}°C</span>
+            <span className="drole">{v.role !== '—' ? v.role : ''}</span>
+            <span className="temp" style={{ marginLeft: 'auto' }}>{v.temp_c}°C</span>
             {v.replacing ? (
               <span className="vdevjoin" title={t('vdev_joining_hint')}>
                 {t('vdev_joining')} · {Math.round(pool.scrub.pct)}%
@@ -254,7 +261,7 @@ export function PoolCard({ pool, onChanged }: { pool: Pool; onChanged: () => voi
 
       {err && <p className="form-err" style={{ padding: '0 16px' }} role="alert">{err}</p>}
 
-      <div style={{ display: 'flex', gap: 7, padding: '0 16px 15px', flexWrap: 'wrap' }}>
+      <div className="pool-actions">
         {!resilvering && !expanding && (
           <button className="btn sm" title={running ? t('pool_scrub_pause_hint') : t('pool_scrub_hint')}
             onClick={() => scrub(running ? 'pause' : 'start')}>

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -194,12 +194,13 @@ export function InfoBubble({ title, glyph = '?', children }: { title?: string; g
 }
 
 // Pie de tarjeta KPI con valor opcional de porcentaje
-export function KpiCard({ label, value, small, foot, meter }: {
+export function KpiCard({ label, value, small, foot, meter, led }: {
   label: string; value: ReactNode; small?: string; foot?: ReactNode; meter?: number;
+  led?: 'g' | 'a' | 'r' | 'c' | 'o';
 }) {
   return (
     <div className="card kpi">
-      <div className="lbl">{label}</div>
+      <div className="lbl">{led && <span className={`led ${led}`} />}{label}</div>
       <div className="val">{value}{small ? <> <small>{small}</small></> : null}</div>
       {meter !== undefined && <Meter pct={meter} />}
       {foot && <div className="foot">{foot}</div>}

--- a/web/src/data/mock.ts
+++ b/web/src/data/mock.ts
@@ -54,6 +54,9 @@ export class MockProvider implements DataProvider {
     uptime_sec: 17 * 86400 + 4 * 3600, rss_bytes: 21 * 1024 ** 2,
     db_bytes: Math.round(8.4 * 1024 ** 2), db_path: '/var/lib/easyzfs/app.db',
     zfs_version: '2.4.1', demo: true,
+    load1: 0.42, load5: 0.38, load15: 0.31,
+    mem_total_bytes: 8 * 1024 ** 3, mem_avail_bytes: Math.round(4.9 * 1024 ** 3),
+    arc_hit_pct: 97.4, arc_size_bytes: Math.round(1.8 * 1024 ** 3),
     capabilities: {
       rewrite: true, raidz_expansion: true, scrub_all: true,
       scrub_range: true, zarc_names: true, json_output: true, version: '2.4.1',

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -71,6 +71,15 @@ export interface VersionInfo {
   demo: boolean;
   capabilities?: Capabilities; // ausente en respuestas viejas del server
   pendingUpdate?: { from: string; to: string } | null;
+  // Métricas del host (best effort; ausentes si el server no puede leerlas,
+  // p. ej. fuera de Linux o sin ZFS cargado).
+  load1?: number;
+  load5?: number;
+  load15?: number;
+  mem_total_bytes?: number;
+  mem_avail_bytes?: number;
+  arc_hit_pct?: number;
+  arc_size_bytes?: number;
 }
 
 // Estado de actualización (GET /api/update/status). El apply lo ejecuta el

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -58,7 +58,9 @@ label{font-size:12px;font-weight:600;color:var(--text2);display:block;margin:12p
    minmax: las pistas vacías colapsan, así que con menos pools de los que
    caben no queda una columna fantasma */
 @media(min-width:1500px){
-  .grid.pools{grid-template-columns:repeat(auto-fit,minmax(min(100%,560px),1fr)) !important;align-items:start}
+  /* Las tarjetas de pool van siempre a ancho completo (diseño del mockup):
+     cada pool es una banda con cabecera, barra segmentada y vdevs */
+  .grid.pools{grid-template-columns:1fr !important;align-items:start}
 }
 aside.sidebar{
   display:none; width:218px; flex-shrink:0; padding:22px 14px;
@@ -1158,3 +1160,280 @@ html.reduce-motion *{transition:none!important;animation:none!important}
 .tpv-scope:only-child{flex:1}
 /* nota en lugar del picker de acento cuando hay skin activo */
 .accent-note{font-size:12px;color:var(--text3);font-style:italic}
+
+/* ================================================================
+   SKINS — capa 2: componentes.
+   El lenguaje visual del mockup aplicado a los componentes reales
+   (tarjetas, KPIs, tablas, botones, nav, header, toasts, modales).
+   Todo gated por [data-theme="<skin>"]: el clásico no cambia.
+   ================================================================ */
+
+/* ---------- reloj de consola en la topbar (elemento nuevo) ---------- */
+.clock{
+  font-family:var(--font-mono);font-size:12.5px;color:var(--text2);
+  font-variant-numeric:tabular-nums;letter-spacing:.04em;white-space:nowrap;
+}
+.clock b{color:var(--text);font-weight:500}
+@media(max-width:1100px){.clock{display:none}}
+
+/* ---------- todos los skins ---------- */
+/* selección con el acento del skin */
+[data-theme="modern-dark"] ::selection,
+[data-theme="modern-light"] ::selection,
+[data-theme="phosphor"] ::selection,
+[data-theme="brutalist"] ::selection{background:var(--accent);color:var(--on-accent)}
+/* scrollbars finas acordes al skin */
+[data-theme="modern-dark"]::-webkit-scrollbar,
+[data-theme="modern-light"]::-webkit-scrollbar,
+[data-theme="phosphor"]::-webkit-scrollbar,
+[data-theme="brutalist"]::-webkit-scrollbar{width:10px;height:10px}
+[data-theme="modern-dark"]::-webkit-scrollbar-track,
+[data-theme="modern-light"]::-webkit-scrollbar-track,
+[data-theme="phosphor"]::-webkit-scrollbar-track,
+[data-theme="brutalist"]::-webkit-scrollbar-track{background:var(--bg)}
+[data-theme="modern-dark"]::-webkit-scrollbar-thumb,
+[data-theme="modern-light"]::-webkit-scrollbar-thumb,
+[data-theme="phosphor"]::-webkit-scrollbar-thumb,
+[data-theme="brutalist"]::-webkit-scrollbar-thumb{background:var(--border);border-radius:99px}
+[data-theme="phosphor"]::-webkit-scrollbar-thumb,
+[data-theme="brutalist"]::-webkit-scrollbar-thumb{border-radius:0}
+/* filas de tabla con hover de acento */
+[data-theme="modern-dark"] table.data tbody tr,
+[data-theme="modern-light"] table.data tbody tr,
+[data-theme="phosphor"] table.data tbody tr,
+[data-theme="brutalist"] table.data tbody tr{transition:background .12s}
+[data-theme="modern-dark"] table.data tbody tr:hover,
+[data-theme="modern-light"] table.data tbody tr:hover,
+[data-theme="phosphor"] table.data tbody tr:hover,
+[data-theme="brutalist"] table.data tbody tr:hover{background:var(--accent-soft)}
+
+/* ---------- MODERN (ambos): títulos con línea, KPI grande, hover con halo ---------- */
+[data-theme="modern-dark"] .cardtitle,
+[data-theme="modern-light"] .cardtitle,
+[data-theme="phosphor"] .cardtitle{display:flex;align-items:center;gap:12px}
+[data-theme="modern-dark"] .cardtitle::after,
+[data-theme="modern-light"] .cardtitle::after,
+[data-theme="phosphor"] .cardtitle::after{content:"";flex:1;height:1px;background:var(--border)}
+/* la banda de las admin-cards ya tiene su propio tratamiento: sin línea */
+[data-theme="modern-dark"] .admin-card .cardtitle::after,
+[data-theme="modern-light"] .admin-card .cardtitle::after,
+[data-theme="phosphor"] .admin-card .cardtitle::after{content:none}
+[data-theme="modern-dark"] header.top h1,
+[data-theme="modern-light"] header.top h1{font-weight:800;letter-spacing:-.02em}
+[data-theme="modern-dark"] .kpi .val,
+[data-theme="modern-light"] .kpi .val{font-size:30px;font-weight:800}
+[data-theme="modern-dark"] .meter,
+[data-theme="modern-light"] .meter{height:8px}
+[data-theme="modern-dark"] .btn:hover,
+[data-theme="modern-light"] .btn:hover{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+[data-theme="modern-dark"] .seg button.on,
+[data-theme="modern-light"] .seg button.on{background:var(--accent-soft);color:var(--accent);box-shadow:none}
+[data-theme="modern-dark"] .brand svg,
+[data-theme="modern-light"] .brand svg{color:var(--accent)}
+
+/* ---------- PHOSPHOR capa 2: corchetes, viñeta, prompts, títulos ---------- */
+/* botones-comando: [ ETIQUETA ] */
+[data-theme="phosphor"] .btn::before{content:"[";color:var(--text3);font-weight:400}
+[data-theme="phosphor"] .btn::after{content:"]";color:var(--text3);font-weight:400}
+[data-theme="phosphor"] .btn:hover::before,
+[data-theme="phosphor"] .btn:hover::after{color:var(--accent)}
+[data-theme="phosphor"] .btn.primary::before,
+[data-theme="phosphor"] .btn.primary::after{color:inherit;opacity:.5}
+[data-theme="phosphor"] .btn.solid-danger::before,
+[data-theme="phosphor"] .btn.solid-danger::after{color:inherit;opacity:.5}
+/* viñeta CRT (bajo las scanlines, sobre el contenido; no intercepta clics) */
+[data-theme="phosphor"] body::before{
+  content:"";position:fixed;inset:0;z-index:8999;pointer-events:none;
+  background:radial-gradient(ellipse 120% 100% at 50% 50%, transparent 62%, rgba(0,0,0,.38) 100%);
+}
+/* prompt de terminal en la navegación */
+[data-theme="phosphor"] aside.sidebar nav a::before,
+[data-theme="phosphor"] .sideactions a::before{content:"›";color:var(--text3);font-weight:400}
+[data-theme="phosphor"] aside.sidebar nav a.active::before,
+[data-theme="phosphor"] .sideactions a.active::before{color:inherit}
+[data-theme="phosphor"] aside.sidebar.collapsed nav a::before,
+[data-theme="phosphor"] aside.sidebar.collapsed .sideactions a::before{content:none}
+/* logo fósforo */
+[data-theme="phosphor"] .brand svg{color:var(--accent);filter:drop-shadow(0 0 6px rgba(0,244,142,.45))}
+/* títulos de terminal */
+[data-theme="phosphor"] header.top h1{
+  text-transform:uppercase;letter-spacing:.04em;
+  text-shadow:0 0 18px rgba(0,244,142,.25);
+}
+[data-theme="phosphor"] .cardtitle{
+  font-size:11px;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--text2);font-weight:600;
+}
+/* la banda de admin conserva su jerarquía */
+[data-theme="phosphor"] .admin-card .cardtitle{
+  font-size:15px;letter-spacing:-.01em;text-transform:none;color:var(--accent);font-weight:700;
+}
+/* radios duros en todos los controles */
+[data-theme="phosphor"] .iconbtn,
+[data-theme="phosphor"] .theme-pill,
+[data-theme="phosphor"] .theme-pill button,
+[data-theme="phosphor"] .topuser,
+[data-theme="phosphor"] .topuser .avatar,
+[data-theme="phosphor"] .alert .ico,
+[data-theme="phosphor"] .updatebar,
+[data-theme="phosphor"] .relbar,
+[data-theme="phosphor"] .demobar,
+[data-theme="phosphor"] .toast,
+[data-theme="phosphor"] .modal,
+[data-theme="phosphor"] .sel-pop,
+[data-theme="phosphor"] .bottomnav button{border-radius:0}
+/* interruptores cuadrados */
+[data-theme="phosphor"] .switch .track{border-radius:0}
+[data-theme="phosphor"] .switch .track::after{border-radius:0}
+/* cabeceras de tabla técnicas */
+[data-theme="phosphor"] table.data th{letter-spacing:.18em;font-size:10px;color:var(--text3)}
+/* iconos de alerta con halo */
+[data-theme="phosphor"] .alert .ico{box-shadow:0 0 14px color-mix(in srgb, currentColor 35%, transparent)}
+/* reloj en fósforo */
+[data-theme="phosphor"] .clock{color:var(--accent);text-shadow:0 0 8px rgba(0,244,142,.35)}
+[data-theme="phosphor"] .clock b{color:var(--accent)}
+
+/* ---------- BRUTALIST capa 2: titular marcador, logo pegatina, bordes ---------- */
+[data-theme="brutalist"] header.top h1{
+  text-transform:uppercase;letter-spacing:-.01em;
+  background:linear-gradient(transparent 60%, #ffd23f 60%);padding:0 4px;
+}
+[data-theme="brutalist"] .brand svg{
+  background:#ffd23f;border:2px solid #141414;box-shadow:3px 3px 0 #141414;padding:3px;
+}
+[data-theme="brutalist"] .iconbtn{border-radius:0;border-width:2px}
+[data-theme="brutalist"] .theme-pill{border-radius:0;border-width:2px}
+[data-theme="brutalist"] .theme-pill button{border-radius:0}
+[data-theme="brutalist"] .theme-pill button.active{box-shadow:none;background:#141414;color:#ffd23f}
+[data-theme="brutalist"] .topuser{border-radius:0;border-width:2px}
+[data-theme="brutalist"] .alert .ico{border-radius:0}
+[data-theme="brutalist"] .updatebar,
+[data-theme="brutalist"] .relbar,
+[data-theme="brutalist"] .demobar{border-width:2px;border-radius:0}
+[data-theme="brutalist"] .toast{border-width:2px;border-left-width:5px;border-radius:0;box-shadow:4px 4px 0 #141414}
+[data-theme="brutalist"] .modal{border:2px solid #141414;border-radius:0;box-shadow:8px 8px 0 #141414}
+[data-theme="brutalist"] .sel-pop{border-width:2px;border-radius:0}
+[data-theme="brutalist"] .bottomnav{border-top-width:2px}
+[data-theme="brutalist"] .bottomnav button{border-radius:0;text-transform:uppercase;letter-spacing:.04em}
+[data-theme="brutalist"] .switch .track{border-radius:0;border-width:2px;border-color:#141414}
+[data-theme="brutalist"] .switch .track::after{border-radius:0}
+[data-theme="brutalist"] table.data th{border-bottom:2px solid #141414}
+
+/* ================= Capa 3: métricas en vivo (mockup) ================= */
+/* Sidebar: uptime / load / RAM / ARC. Mono, discreto, tabular. */
+.side-stats{
+  margin:10px 10px 4px;padding:10px 12px 8px;
+  border:1px solid var(--border);border-radius:var(--radius-sm);
+  background:var(--surface);
+  font-family:var(--font-mono);font-size:11px;
+  display:flex;flex-direction:column;gap:7px;
+  font-variant-numeric:tabular-nums;
+}
+.ss-row{display:flex;justify-content:space-between;align-items:baseline;gap:10px}
+.ss-row.ss-col{flex-direction:column;align-items:stretch;gap:4px}
+.ss-line{display:flex;justify-content:space-between;align-items:baseline;gap:6px}
+.ss-k{color:var(--text3);font-size:9.5px;letter-spacing:.09em;text-transform:uppercase;white-space:nowrap}
+.ss-v{color:var(--text2);font-size:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.ss-v.g{color:var(--ok)}
+.minibar{height:3px;border-radius:2px;background:var(--surface2);overflow:hidden}
+.minibar i{display:block;height:100%;background:var(--accent);border-radius:2px}
+
+/* Header: badge LIVE con punto pulsante */
+.live-badge{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--font-mono);font-size:10px;letter-spacing:.12em;
+  color:var(--text3);border:1px solid var(--border);border-radius:999px;
+  padding:3px 9px;user-select:none;
+}
+.live-dot{width:6px;height:6px;border-radius:50%;background:var(--ok);animation:livepulse 2s ease-in-out infinite}
+@keyframes livepulse{0%,100%{opacity:1;box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 45%,transparent)}50%{opacity:.55;box-shadow:0 0 0 4px transparent}}
+@media (max-width:1100px){.live-badge{display:none}}
+
+/* LED de estado (pools, discos, datasets, jobs): punto 8px con halo suave */
+.led{width:8px;height:8px;border-radius:50%;display:inline-block;flex:none;background:var(--text3)}
+.led.g{background:var(--ok);box-shadow:0 0 6px color-mix(in srgb,var(--ok) 60%,transparent)}
+.led.a{background:var(--warn);box-shadow:0 0 6px color-mix(in srgb,var(--warn) 60%,transparent)}
+.led.r{background:var(--err);box-shadow:0 0 6px color-mix(in srgb,var(--err) 60%,transparent)}
+.led.c{background:var(--accent);box-shadow:0 0 6px color-mix(in srgb,var(--accent) 60%,transparent)}
+.led.o{background:var(--text3);opacity:.5;box-shadow:none}
+
+/* ---------- ajustes por piel ---------- */
+[data-theme="phosphor"] .side-stats{
+  background:transparent;border-color:color-mix(in srgb,var(--ok) 30%,transparent);
+  box-shadow:inset 0 0 18px color-mix(in srgb,var(--ok) 6%,transparent);
+}
+[data-theme="phosphor"] .ss-v{color:var(--ok);text-shadow:0 0 6px color-mix(in srgb,var(--ok) 45%,transparent)}
+[data-theme="phosphor"] .ss-k{color:color-mix(in srgb,var(--ok) 55%,transparent)}
+[data-theme="phosphor"] .minibar{background:color-mix(in srgb,var(--ok) 14%,transparent)}
+[data-theme="phosphor"] .minibar i{background:var(--ok);box-shadow:0 0 6px var(--ok)}
+[data-theme="phosphor"] .live-badge{border-color:color-mix(in srgb,var(--ok) 40%,transparent);color:var(--ok);border-radius:0;text-shadow:0 0 6px color-mix(in srgb,var(--ok) 45%,transparent)}
+[data-theme="phosphor"] .live-dot{border-radius:0}
+[data-theme="phosphor"] .led{border-radius:0}
+[data-theme="brutalist"] .side-stats{border:2px solid #141414;border-radius:0;background:var(--surface)}
+[data-theme="brutalist"] .minibar{border-radius:0;border:1px solid #141414}
+[data-theme="brutalist"] .minibar i{border-radius:0}
+[data-theme="brutalist"] .live-badge{border:2px solid #141414;border-radius:0;color:var(--text)}
+[data-theme="brutalist"] .led{border-radius:0;box-shadow:none;border:1px solid #141414}
+
+/* ================= Capa 3b: tarjetas de pool (mockup) ================= */
+.pool-head{display:flex;align-items:center;gap:12px;padding:16px 16px 12px;flex-wrap:wrap}
+.pool-head>.led{width:10px;height:10px}
+.pool-head .grow{flex:1;min-width:180px}
+.pool-name{font-size:16px;font-weight:700;display:flex;gap:9px;align-items:center;letter-spacing:-.01em}
+.pool-raid{font-family:var(--font-mono);font-size:11.5px;color:var(--text2);margin-top:3px;display:flex;gap:6px;align-items:center}
+.pool-cap{text-align:right;margin-left:auto}
+.pool-cap .big{font-family:var(--font-mono);font-weight:700;font-size:18px;font-variant-numeric:tabular-nums}
+.pool-cap .big .dim{color:var(--text3);font-weight:500;font-size:13px}
+.pool-cap .pct{font-size:12px;color:var(--text2);margin-top:2px}
+.pool-bar{padding:0 16px 12px}
+.pool-bar .sparks{margin-top:10px}
+.segbar{height:10px;border-radius:99px;background:var(--surface2);overflow:hidden}
+.segbar>i{display:block;height:100%;border-radius:99px;background:var(--accent);transition:width .4s ease}
+.segbar.warn>i{background:var(--warn)}
+.segbar.crit>i{background:var(--err)}
+.poolmeta{font-family:var(--font-mono);font-size:11.5px;gap:16px}
+.vdev .drole{font-size:12px;color:var(--text2)}
+.vdev .temp{font-family:var(--font-mono);font-size:12.5px;color:var(--text2);font-variant-numeric:tabular-nums}
+.vdev.faulted .dname{color:var(--err)}
+.vdev.out{opacity:.55}
+.pool-actions{display:flex;gap:7px;padding:12px 16px 15px;flex-wrap:wrap;border-top:1px solid var(--border)}
+[data-density="compact"] .pool-head{padding:12px 12px 8px}
+[data-density="compact"] .pool-bar{padding:0 12px 8px}
+[data-density="compact"] .pool-actions{padding:8px 12px 12px}
+[data-theme="phosphor"] .pool-name{text-transform:uppercase;letter-spacing:.04em;text-shadow:0 0 8px color-mix(in srgb,var(--ok) 40%,transparent)}
+[data-theme="phosphor"] .segbar{background:color-mix(in srgb,var(--ok) 12%,transparent);border-radius:0}
+[data-theme="phosphor"] .segbar>i{border-radius:0;background:var(--ok);box-shadow:0 0 8px color-mix(in srgb,var(--ok) 60%,transparent)}
+[data-theme="phosphor"] .segbar.warn>i{background:var(--warn);box-shadow:0 0 8px color-mix(in srgb,var(--warn) 60%,transparent)}
+[data-theme="phosphor"] .segbar.crit>i{background:var(--err);box-shadow:0 0 8px color-mix(in srgb,var(--err) 60%,transparent)}
+[data-theme="phosphor"] .pool-cap .big{color:var(--ok);text-shadow:0 0 8px color-mix(in srgb,var(--ok) 40%,transparent)}
+[data-theme="brutalist"] .segbar{border:2px solid #141414;border-radius:0;height:12px}
+[data-theme="brutalist"] .segbar>i{border-radius:0}
+[data-theme="brutalist"] .pool-actions{border-top:2px solid #141414}
+
+/* ================= Capa 3c: dashboard (mockup) ================= */
+.kpi .lbl{display:flex;align-items:center;gap:7px}
+.kpi .lbl .led{width:7px;height:7px}
+.dev{display:flex;align-items:center;gap:10px;padding:6px 0;font-size:13px}
+.dev+.dev{border-top:1px solid var(--border)}
+.dev .dname{font-family:var(--font-mono);font-size:12.5px;color:var(--text)}
+.dev .drole{font-size:12px;color:var(--text3)}
+.dev .temp{font-family:var(--font-mono);font-size:12.5px;color:var(--text2);font-variant-numeric:tabular-nums}
+.dev .minibar{width:90px;flex:none}
+.evt-card{padding:8px 16px 10px}
+.evt-log{font-family:var(--font-mono);font-size:12px;line-height:1.5;display:flex;flex-direction:column}
+.evt{display:flex;gap:12px;padding:4px 0;align-items:baseline}
+.evt+.evt{border-top:1px dashed var(--border)}
+.evt .ts{color:var(--text3);white-space:nowrap;font-size:11px;flex:none}
+.evt .msg{color:var(--text2);min-width:0}
+.evt .msg .dim{color:var(--text3)}
+[data-theme="phosphor"] .evt .ts{color:color-mix(in srgb,var(--ok) 55%,transparent)}
+[data-theme="phosphor"] .evt .msg{color:var(--ok);text-shadow:0 0 5px color-mix(in srgb,var(--ok) 30%,transparent)}
+[data-theme="phosphor"] .evt+.evt{border-top-color:color-mix(in srgb,var(--ok) 20%,transparent)}
+[data-theme="brutalist"] .evt+.evt{border-top:1px solid #141414}
+
+/* ================= Capa 3d: tablas (mockup) ================= */
+.dim{color:var(--text3)}
+.ledcol{width:26px;text-align:center;padding-right:0!important}
+table.data td.ledcol,table.data th.ledcol{width:26px}
+.tree{color:var(--text3);font-weight:400;user-select:none}
+[data-theme="phosphor"] .tree{color:color-mix(in srgb,var(--ok) 50%,transparent)}

--- a/web/src/ui/i18n.ts
+++ b/web/src/ui/i18n.ts
@@ -93,6 +93,7 @@ const es = {
   kpi_scrub: 'Último scrub', kpi_scrub_errors: 'errores',
   dash_pools: 'Pools', dash_see_all: 'Ver todos',
   dash_alerts: 'Alertas recientes', dash_activity: 'Actividad',
+  dash_temps: 'Temperatura de discos', dash_events: 'Registro de eventos',
   dash_no_alerts: 'Sin alertas. Todo en orden.',
 
   // Tendencias (#85)
@@ -246,7 +247,7 @@ const es = {
   nds_pass_mismatch: 'Las passphrases no coinciden',
   ds_encrypted: 'cifrado', ds_locked: 'bloqueado (sin clave)', ds_unlocked: 'desbloqueado',
   ds_rename: 'Renombrar', ds_rename_ph: 'nuevo/nombre',
-  ds_mount: 'Montar', ds_unmount: 'Desmontar', ds_promote: 'Promocionar',
+  ds_mount: 'Montar', ds_unmount: 'Desmontar', ds_promote: 'Promocionar', ds_mountpoint: 'Punto de montaje',
   ds_unmount_err: 'No se pudo desmontar: el dataset puede estar en uso',
   ds_promote_hint: 'Invierte la clonación: este dataset pasa a ser el origen',
   ds_unlock: 'Desbloquear', ds_lock: 'Bloquear', ds_changekey: 'Cambiar clave',
@@ -705,6 +706,7 @@ const en: Record<I18nKey, string> = {
   kpi_scrub: 'Last scrub', kpi_scrub_errors: 'errors',
   dash_pools: 'Pools', dash_see_all: 'View all',
   dash_alerts: 'Recent alerts', dash_activity: 'Activity',
+  dash_temps: 'Disk temperatures', dash_events: 'Event log',
   dash_no_alerts: 'No alerts. Everything is fine.',
 
   // Trends (#85)
@@ -852,7 +854,7 @@ const en: Record<I18nKey, string> = {
   nds_pass_mismatch: 'Passphrases do not match',
   ds_encrypted: 'encrypted', ds_locked: 'locked (no key)', ds_unlocked: 'unlocked',
   ds_rename: 'Rename', ds_rename_ph: 'new/name',
-  ds_mount: 'Mount', ds_unmount: 'Unmount', ds_promote: 'Promote',
+  ds_mount: 'Mount', ds_unmount: 'Unmount', ds_promote: 'Promote', ds_mountpoint: 'Mountpoint',
   ds_unmount_err: 'Could not unmount: the dataset may be in use',
   ds_promote_hint: 'Reverses cloning: this dataset becomes the origin',
   ds_unlock: 'Unlock', ds_lock: 'Lock', ds_changekey: 'Change key',

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { subscribeEvents } from '../data/events';
 import { useData } from '../ui/useData';
 import { useApp, alertTargetView } from '../ui/store';
-import { fmtBytes, fmtBytesPair, fmtInt, fmtPct, timeAgo } from '../ui/format';
+import { fmtBytes, fmtBytesPair, fmtDateTime, fmtInt, fmtPct, timeAgo } from '../ui/format';
 import { KpiCard, Spinner } from '../components/ui';
 import { PoolCard } from '../components/PoolCard';
 import { Donut } from '../components/Donut';
@@ -70,16 +70,17 @@ export default function Dashboard() {
       {!o && <Spinner label={t('loading')} />}
       {o && (<>
         <div className="grid kpis">
-          <KpiCard label={t('kpi_health')}
+          <KpiCard label={t('kpi_health')} led={o.pools_online === o.pools_total ? 'g' : 'a'}
             value={`${o.pools_total} pools`}
             foot={o.pools_online === o.pools_total ? t('kpi_health_ok') : t('kpi_health_warn')} />
-          <KpiCard label={t('kpi_cap')}
+          <KpiCard label={t('kpi_cap')} led={pct >= 90 ? 'r' : pct >= 80 ? 'a' : 'c'}
             value={cap!.used}
             small={`${t('pool_of')} ${cap!.total}`}
             foot={`${fmtPct(pct)} ${t('kpi_cap_used')}`} meter={pct} />
-          <KpiCard label={t('kpi_snaps')} value={fmtInt(o.snapshots_total)}
+          <KpiCard label={t('kpi_snaps')} led="c" value={fmtInt(o.snapshots_total)}
             foot={`${o.jobs_active} ${t('kpi_snaps_foot')}`} />
-          <KpiCard label={t('kpi_scrub')} value={o.last_scrub.errors === 0 ? 'OK' : String(o.last_scrub.errors)}
+          <KpiCard label={t('kpi_scrub')} led={o.last_scrub.errors === 0 ? 'g' : 'r'}
+            value={o.last_scrub.errors === 0 ? 'OK' : String(o.last_scrub.errors)}
             foot={`${o.last_scrub.pool} · ${o.last_scrub.errors} ${t('kpi_scrub_errors')} · ${timeAgo(o.last_scrub.ts, t)}`} />
         </div>
 
@@ -149,9 +150,6 @@ export default function Dashboard() {
           </div>
         )}
 
-        {/* Alertas + Actividad: apiladas en pantalla normal; en ancha van a
-            2 columnas (dash-cols) para no dejar media pantalla vacía */}
-        <div className="dash-cols">
         <div className="sect">
           <h2>{t('dash_alerts')}</h2>
           <div className="card">
@@ -160,18 +158,41 @@ export default function Dashboard() {
           </div>
         </div>
 
+        {/* grid2 del mockup: temperaturas de disco (LED + minibarra) y
+            actividad reciente con formato de registro de eventos */}
+        <div className="dash-cols">
         <div className="sect">
-          <h2>{t('dash_activity')}</h2>
-          <div className="card">
-            {o.activity.map((a, i) => (
-              <div className="rowitem" key={i}>
-                <div className="grow">
-                  <div className="t1" style={{ fontSize: 13.5 }}>{a.text}</div>
-                  <div className="t2">{a.detail}</div>
+          <h2>{t('dash_temps')}</h2>
+          <div className="card" style={{ padding: '10px 16px 12px' }}>
+            {(!disks.data || disks.data.length === 0) && <div className="empty">{t('empty')}</div>}
+            {(disks.data ?? []).map((d) => {
+              const tC = d.temp_c;
+              const w = tC == null ? 0 : Math.min(100, Math.round((tC / 70) * 100));
+              return (
+                <div className="dev" key={d.dev}>
+                  <span className={`led ${d.smart === 'ok' ? 'g' : d.smart === 'warn' ? 'a' : d.smart === 'crit' ? 'r' : 'o'}`} />
+                  <span className="dname" title={d.model}>{d.dev.replace('/dev/', '')}</span>
+                  <span className="drole">{d.pool && d.pool !== '—' ? d.pool : ''}</span>
+                  <span className="temp" style={{ marginLeft: 'auto' }}>{tC == null ? '—' : `${tC}°C`}</span>
+                  <span className="minibar" style={{ width: 90 }}><i style={{ width: `${w}%` }} /></span>
                 </div>
-                <span style={{ fontSize: 11.5, color: 'var(--text2)' }}>{timeAgo(a.ts, t)}</span>
-              </div>
-            ))}
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="sect">
+          <h2>{t('dash_events')}</h2>
+          <div className="card evt-card">
+            <div className="evt-log">
+              {o.activity.map((a, i) => (
+                <div className="evt" key={i}>
+                  <span className="ts">{fmtDateTime(a.ts)}</span>
+                  <span className="msg">{a.text}{a.detail ? <span className="dim"> · {a.detail}</span> : null}</span>
+                </div>
+              ))}
+              {o.activity.length === 0 && <div className="empty">{t('empty')}</div>}
+            </div>
           </div>
         </div>
         </div>

--- a/web/src/views/Datasets.tsx
+++ b/web/src/views/Datasets.tsx
@@ -29,6 +29,17 @@ export default function Datasets() {
     try { await fn(); } catch (e) { setErr(errorMessage(e, t)); }
   };
 
+  // Glifo de árbol estilo mockup: "├─" para hijos, "└─" para el último hijo
+  // de cada padre (la lista ya viene ordenada jerárquicamente del backend).
+  const treeGlyph = (name: string, idx: number, all: typeof data): string => {
+    if (!all) return '';
+    const slash = name.lastIndexOf('/');
+    if (slash < 0) return '';
+    const parent = name.slice(0, slash);
+    const isLast = !all.slice(idx + 1).some((x) => x.name.startsWith(parent + '/') && x.name.split('/').length === name.split('/').length);
+    return isLast ? '└─' : '├─';
+  };
+
   return (
     <div className="view">
       {loading && !data && <Spinner label={t('loading')} />}
@@ -36,12 +47,13 @@ export default function Datasets() {
         <table className="data">
           <thead>
             <tr>
-              <th className="slack">{t('ds_name')}</th><th>{t('ds_type')}</th><th>{t('ds_comp')}</th>
-              <th className="num">{t('ds_used')}</th><th className="num">{t('ds_avail')}</th><th className="num">{t('ds_quota')}</th><th />
+              <th className="ledcol" /><th className="slack">{t('ds_name')}</th><th>{t('ds_type')}</th><th>{t('ds_comp')}</th>
+              <th className="num">{t('ds_used')}</th><th className="num">{t('ds_avail')}</th><th className="num">{t('ds_quota')}</th>
+              <th className="hide-md">{t('ds_mountpoint')}</th><th />
             </tr>
           </thead>
           <tbody>
-            {(data ?? []).map((d) => {
+            {(data ?? []).map((d, di) => {
               const rewriting = running.has(d.name);
               const canRewrite = isAdmin && !!caps?.rewrite && d.type === 'fs' &&
                 !!d.mountpoint && d.mountpoint !== '—' && d.mountpoint !== '-' && d.mountpoint !== 'none' && d.mountpoint !== 'legacy';
@@ -50,7 +62,13 @@ export default function Datasets() {
               return (
               <tr className="clickable" key={d.name}
                 onClick={() => openModal('propsds', { ds: d })}>
+                <td className="ledcol">
+                  <span className={`led ${encrypted && !unlocked ? 'a' : d.type === 'volume' ? 'c' : 'g'}`} />
+                </td>
                 <td className="mono" style={{ fontWeight: 600 }}>
+                  {treeGlyph(d.name, di, data) && (
+                    <span className="tree" aria-hidden="true">{treeGlyph(d.name, di, data)} </span>
+                  )}
                   {encrypted && (
                     <span style={{ display: 'inline-flex', verticalAlign: '-3px', marginRight: 6,
                       color: unlocked ? 'var(--ok)' : 'var(--err)' }}
@@ -71,7 +89,8 @@ export default function Datasets() {
                 <td>{d.compression}</td>
                 <td className="num">{fmtBytes(d.used_bytes)}</td>
                 <td className="num">{fmtBytes(d.avail_bytes)}</td>
-                <td className="num">{d.quota_bytes ? fmtBytes(d.quota_bytes) : '—'}</td>
+                <td className="num">{d.quota_bytes ? fmtBytes(d.quota_bytes) : <span className="dim">—</span>}</td>
+                <td className="mono dim hide-md" style={{ fontSize: 12 }}>{d.mountpoint || '—'}</td>
                 <td style={{ whiteSpace: 'nowrap' }}>
                   {encrypted && isAdmin && (<>
                     {!unlocked && (

--- a/web/src/views/Disks.tsx
+++ b/web/src/views/Disks.tsx
@@ -128,7 +128,7 @@ export default function Disks() {
         <table className="data responsive">
           <thead>
             <tr>
-              <th>{t('dk_disk')}</th><th className="slack">{t('dk_model')}</th><th className="num hide-md">{t('dk_size')}</th>
+              <th className="ledcol" /><th>{t('dk_disk')}</th><th className="slack">{t('dk_model')}</th><th className="num hide-md">{t('dk_size')}</th>
               <th className="num">{t('dk_temp')}</th><th>{t('dk_smart')}</th><th className="hide-md">{t('dk_pool')}</th><th />
             </tr>
           </thead>
@@ -137,6 +137,9 @@ export default function Disks() {
               <tr key={d.dev} className="clickable"
                 title={t('dsm_title')}
                 onClick={() => openModal('diskdetail', { disk: d })}>
+                <td className="ledcol">
+                  <span className={`led ${d.smart === 'ok' ? 'g' : d.smart === 'warn' ? 'a' : d.smart === 'crit' ? 'r' : 'o'}`} />
+                </td>
                 <td className="mono" style={{ fontWeight: 650 }}>{d.dev}</td>
                 <td className="modelcell">
                   <div style={{ fontSize: 13 }}>{d.model}</div>
@@ -145,7 +148,7 @@ export default function Disks() {
                   </div>
                 </td>
                 <td className="num hide-md" data-l={t('dk_size')}>{fmtBytes(d.size_bytes)}</td>
-                <td className="num" data-l={t('dk_temp')}>
+                <td className="num mono" data-l={t('dk_temp')} style={{ fontVariantNumeric: 'tabular-nums' }}>
                   {d.temp_c === null ? '—' : `${d.temp_c}°C`}
                   <DiskTempSpark dev={d.dev} />
                 </td>

--- a/web/src/views/Snapshots.tsx
+++ b/web/src/views/Snapshots.tsx
@@ -65,6 +65,7 @@ export default function Snapshots() {
               onClick={() => toggle(g.dataset)}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(g.dataset); } }}>
               <span className="chev" style={{ display: 'inline-flex' }}><IconChev /></span>
+              <span className={`led ${g.snaps.length > 0 ? 'g' : 'o'}`} />
               <span className="mono" style={{ fontWeight: 650, fontSize: 13.5 }}>{g.dataset}</span>
               <span className="badge info" style={{ marginLeft: 'auto' }}>{g.snaps.length}</span>
             </div>
@@ -73,7 +74,7 @@ export default function Snapshots() {
                 <div className="snap" key={s.full}>
                   <Badge tone={s.kind === 'manual' ? 'warn' : 'info'} dot={false} style={{ padding: '2px 8px' }}>{s.kind}</Badge>
                   <span className="mono">{s.name}</span>
-                  <span style={{ color: 'var(--text2)', fontSize: 12 }}>
+                  <span className="mono" style={{ color: 'var(--text2)', fontSize: 12, fontVariantNumeric: 'tabular-nums' }}>
                     {fmtBytes(s.used_bytes)} · {timeAgo(s.ts, t)}
                   </span>
                   <span className="actions" style={{ marginLeft: 'auto' }}>

--- a/web/src/views/Tasks.tsx
+++ b/web/src/views/Tasks.tsx
@@ -112,6 +112,7 @@ export default function Tasks() {
         <div className="card">
           {list.map((j) => (
             <div className="rowitem" key={j.id}>
+              <span className={`led ${j.enabled ? 'g' : 'o'}`} />
               <div className="grow">
                 <div className="t1" style={{ fontSize: 13.5 }}>
                   <Badge tone={TIPO_CLS[j.tipo]} dot={false} style={{ padding: '2px 8px' }}>{tipoLbl(j.tipo)}</Badge>
@@ -209,6 +210,7 @@ export default function Tasks() {
           {sys.loading && !sys.data && <Spinner label={t('loading')} />}
           {(sys.data?.timers ?? []).map((s, i) => (
             <div className="rowitem" key={i}>
+              <span className={`led ${s.source === 'systemd' ? 'c' : 'a'}`} />
               <Badge tone={s.source === 'systemd' ? 'info' : 'warn'} dot={false} style={{ padding: '2px 8px' }}>
                 {s.source}
               </Badge>
@@ -273,6 +275,7 @@ export default function Tasks() {
         <div className="card">
           {(hist.data ?? []).map((h, i) => (
             <div className="rowitem" key={i}>
+              <span className={`led ${h.ok ? 'g' : 'r'}`} />
               <Badge tone={h.ok ? 'ok' : 'err'} dot={false} style={{ padding: '2px 8px' }}>
                 {h.ok ? t('hist_ok') : t('hist_warn')}
               </Badge>


### PR DESCRIPTION
## Qué hace

Porta el rediseño completo del mockup (la capa 3 estructural) sobre el motor de temas ya mergeado (#130/#131). Todo gated por `[data-theme]`; el tema Classic queda pixel a pixel igual.

closes #132

## Cambios

- **Backend** (`internal/httpapi/system.go`): `/api/version` expone (best-effort) `load1/5/15`, `mem_total_bytes`/`mem_avail_bytes`, `arc_hit_pct`/`arc_size_bytes`.
- **Sidebar**: bloque de stats del sistema (UPTIME, LOAD 1/5/15, RAM daemon+sistema con minibarra, ARC HIT), refresco 30s, degrada con elegancia.
- **Badge LIVE** con punto pulsante junto al reloj.
- **Tarjetas de pool a ancho completo** (corregido el `!important` de `@media(min-width:1500px)`): LED de estado, topología mono, capacidad grande + %, segbar 10px, metadatos mono, filas de vdev con LED/rol/temperatura, fila de acciones separada por hairline.
- **Dashboard**: LEDs en KPIs; rejilla de 2 columnas con temperaturas de discos (LED + minibarra) y registro de eventos; alertas a ancho completo encima.
- **Datasets**: columna de LED, glifos de árbol `├─`/`└─`, columna de punto de montaje.
- **Disks / Tasks / Snapshots**: LEDs de estado en filas, trabajos, timers, historial, grupos.
- Overrides por familia (LEDs cuadrados y glow en Phosphor/Brutalist, bordes duros en Brutalist).

## Verificación

- `go build ./...` OK · `go test ./...` OK · `npm run build` OK.
- Validado visualmente en modo demo (DEMO=1). Classic sin cambios.

## Notas

- Sin migraciones de datos ni de preferencias.
- Boot CRT y ticker NO incluidos (fuera de producción).
- Modern sigue siendo el tema por defecto.